### PR TITLE
Cleanup container after exit:          - Containers are not reused for each build.     - On my Jenkins slave, containers are accumutated     - It's better to remove container with option --rm once build is done

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -125,7 +125,7 @@ docker_run() {
 		done
 	fi
 
-	docker run --privileged -v "$PWD":/home/builder/src \
+	docker run --rm --privileged -v "$PWD":/home/builder/src \
 	       -v ~/.ssh:/home/builder/.ssh \
 	       $extravol \
 	       ${nojenkins:+ -ti} \


### PR DESCRIPTION
The container is not reused for each build. I have a lot accumulated unused container on my Jenkins slave. I've tested with --rm option to automatically remove the container once build is done.