### PR TITLE
Cleanup container after exit

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -125,7 +125,7 @@ docker_run() {
 		done
 	fi
 
-	docker run --privileged -v "$PWD":/home/builder/src \
+	docker run --rm --privileged -v "$PWD":/home/builder/src \
 	       -v ~/.ssh:/home/builder/.ssh \
 	       $extravol \
 	       ${nojenkins:+ -ti} \


### PR DESCRIPTION
 - Containers are not reused for each build
 - On my Jenkins slave, containers are kept and take spaces
 - It's better to remove container with option --rm once build is done