### PR TITLE
cqfd: set the release section optionnal when using flavor

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -195,7 +195,10 @@ config_load() {
 	fi
 	build_cmd="$command"
 
-	cfg.section.release
+	# The release section is optionnal when using flavor
+	if [ -z "$files" ]; then
+		cfg.section.release
+	fi
 	release_files="$files"
 
 	# This will look like fooinc_reponame


### PR DESCRIPTION
When using a flavor the files to release could have already been defined
in the flavor section.
This commit removes the need to have a release section in that case.