### PR TITLE
Support --add-host docker run option

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,10 @@ tasks:
 mappings to be configured inside the started container. Format is the
 same as (and passed to) docker-run’s -v option.
 
+``CQFD_EXTRA_HOSTS``: A space-separated list of additional host
+mappings to be configured inside the started container. Format is the
+same as (and passed to) docker-run’s --add-host option.
+
 ### Other command-line options ###
 
 In some conditions you may want to use an alternate config file with

--- a/cqfd
+++ b/cqfd
@@ -130,10 +130,18 @@ docker_run() {
 		done
 	fi
 
+	if [ -n "$CQFD_EXTRA_HOSTS" ]; then
+		local map extrahosts
+		for map in $CQFD_EXTRA_HOSTS; do
+			extrahosts+="--add-host $map "
+		done
+	fi
+
 	docker run --privileged -v "$PWD":/home/builder/src \
 	       -v ~/.ssh:/home/builder/.ssh \
 	       --rm \
 	       $extravol \
+	       $extrahosts \
 	       ${nojenkins:+ -ti} \
 	       ${SSH_AUTH_SOCK:+ -v $SSH_AUTH_SOCK:/home/builder/.sockets/ssh} \
 	       ${SSH_AUTH_SOCK:+ -e SSH_AUTH_SOCK=/home/builder/.sockets/ssh} \

--- a/tests/05-cqfd_run_extra_hosts
+++ b/tests/05-cqfd_run_extra_hosts
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+. `dirname $0`/jtest.inc "$1"
+cqfd="$TDIR/.cqfd/cqfd"
+getent_cmd="getent hosts 1.2.3.4"
+
+cd $TDIR
+
+# First pass: no cqfd_extra_hosts
+# Second pass: cqfd_extra_hosts defined
+
+for i in 0 1; do
+    if [ "$i" = "0" ]; then
+        jtest_prepare "run cqfd without extra hosts, pass $i"
+        output=$($cqfd run $getent_cmd ; exit 0)
+
+        if [ "$output" = "" ]; then
+            jtest_result pass
+        else
+            jtest_result fail
+        fi
+    fi
+
+    if [ "$i" = "1" ]; then
+        jtest_prepare "run cqfd with extra hosts, pass $i"
+        output=$(CQFD_EXTRA_HOSTS="testhost:1.2.3.4" $cqfd run $getent_cmd ; exit 0)
+
+        if [[ "$output" == *"1.2.3.4"*"testhost"* ]]; then
+            jtest_result pass
+        else
+            jtest_result fail
+        fi
+    fi
+done


### PR DESCRIPTION
My use case is testing some salt commands:

    sevag@sevag-ThinkPad-T460s:~/repos/salt$ export CQFD_EXTRA_HOSTS="salt:127.0.0.1"
    sevag@sevag-ThinkPad-T460s:~/repos/salt$ SALT_CMD="test.ping" salty
    PING salt (127.0.0.1) 56(84) bytes of data.
    64 bytes from localhost (127.0.0.1): icmp_seq=1 ttl=64 time=0.027 ms
    64 bytes from localhost (127.0.0.1): icmp_seq=2 ttl=64 time=0.173 ms
    64 bytes from localhost (127.0.0.1): icmp_seq=3 ttl=64 time=0.056 ms

Should I add tests for this?