### PR TITLE
cqfd: add Dockerfile path for flavors

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -95,8 +95,12 @@ die() {
 }
 
 # docker_build() - Initialize build container
+#
+# arg$1: flavor that could have a specific distro
+#
 docker_build() {
-	config_load
+	local flavor="$1"
+	config_load "$flavor"
 	if [ ! -f $dockerfile ]; then
 		die "no Dockerfile found at location $dockerfile"
 	fi
@@ -248,7 +252,7 @@ while [ $# -gt 0 ]; do
 		exit $ESUCCESS
 		;;
 	init)
-		docker_build
+		docker_build "$flavor"
 		exit $?
 		;;
 	-b)

--- a/tests/01-cqfd_init
+++ b/tests/01-cqfd_init
@@ -11,23 +11,38 @@ jtest_result pass
 
 temp_dir=".cqfd/`mktemp -d`"
 cqfdrc_old=`mktemp`
+flavor=foo
 jtest_prepare "init with a nonexisting dockerfile shall fail"
 cp .cqfdrc $cqfdrc_old
 sed -i -e "s/\[build\]/\[build\]\ndistro='thisshouldfail'/" .cqfdrc
-if $TDIR/.cqfd/cqfd init; then
-	jtest_result fail
-else
-	jtest_result pass
-fi
-
+sed -i -e "s/\[foo\]/\[foo\]\ndistro='thisshouldfail'/" .cqfdrc
+opt_flav=""
+for i in 0 1; do
+        if [ "$i" == "1" ]; then
+	    jtest_prepare "init with a given flavor with a nonexisting dockerfile shall fail"
+	    opt_flav="-b $flavor"
+	fi
+	if $TDIR/.cqfd/cqfd $opt_flav init; then
+	    jtest_result fail
+	else
+	    jtest_result pass
+	fi
+done
 
 jtest_prepare "run cqfd init with an other Dockerfile"
 sed -i -e "s/thisshouldfail/centos/" .cqfdrc
-if $TDIR/.cqfd/cqfd init; then
-	jtest_result pass
-else
-	jtest_result fail
-fi
+opt_flav=""
+for i in 0 1; do
+        if [ "$i" == "1" ]; then
+	    jtest_prepare "run cqfd init with a given flavor with an other Dockerfile"
+	    opt_flav="-b $flavor"
+	fi
+	if $TDIR/.cqfd/cqfd $opt_flav init; then
+	    jtest_result pass
+	else
+	    jtest_result fail
+	fi
+done
 #restore cqfdrc
 mv $cqfdrc_old .cqfdrc
 


### PR DESCRIPTION
Dockerfile paths can be set in the config file using the 'distro' key
in build section.
But this behaviour is just for the build section, not for flavor,
because the config is loaded without the flavor argument. Add it to
activate Dockerfile custom paths in flavors