### PR TITLE
cqfd: allow multiline for files

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -230,7 +230,7 @@ config_load() {
 		dockerfile=".cqfd/$distro/Dockerfile"
 	fi
 
-	release_files="$files"
+	release_files="`eval echo $files`"
 	release_archive="$archive"
 
 	# This will look like fooinc_reponame


### PR DESCRIPTION
Currently, the files property is not ready for a multiline
value.

Example of a multiline files property:
files='README.html \
       README.doc'

The configuration above results in the following shell error:
cqfd: fatal: Cannot create release: missing \

The `\' is not escaped and cqfd tries to test existence of a
file named `\' which does not exists.

This patch evaluates an echo fo the $files variable and
stores the output to $release_files variable.

Signed-off-by: Gaël PORTAY <gael.portay@savoirfairelinux.com>