### PR TITLE
cqfd: usage message nitpick

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -2,7 +2,7 @@
 #
 # cqfd - a tool to wrap commands in controlled Docker containers
 #
-# Copyright (C) 2015-2016 Savoir-faire Linux, Inc.
+# Copyright (C) 2015-2017 Savoir-faire Linux, Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -29,8 +29,9 @@ usage() {
 Usage: $PROGNAME [OPTION ARGUMENT] [COMMAND] [ARGUMENTS]
 
 Options:
-    -f <file>           Use file as config file (default .cqfdrc)
+    -f <file>           Use file as config file (default .cqfdrc).
     -b <flavor_name>    Target a specific build flavor.
+    -h or --help        Show this help text.
 
 Commands:
     init     Initialize project build container
@@ -41,7 +42,7 @@ Commands:
     By default, run is assumed, and the run command is the one
     configured in .cqfdrc.
 
-    cqfd is Copyright (C) 2015-2016 Savoir-faire Linux, Inc.
+    cqfd is Copyright (C) 2015-2017 Savoir-faire Linux, Inc.
 
     This program comes with ABSOLUTELY NO WARRANTY. This is free
     software, and you are welcome to redistribute it under the terms


### PR DESCRIPTION
Both -h and --help options were missing from the usage message.

Add missing `.'.

Also update copyright notice.