### PR TITLE
cqfd: allow init to use flavor option

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -96,7 +96,6 @@ die() {
 
 # docker_build() - Initialize build container
 docker_build() {
-	config_load
 	if [ ! -f $dockerfile ]; then
 		die "no Dockerfile found at location $dockerfile"
 	fi
@@ -252,6 +251,7 @@ while [ $# -gt 0 ]; do
 		exit 0
 		;;
 	init)
+		config_load $flavor
 		docker_build
 		exit $?
 		;;

--- a/tests/05-cqfd_init_flavor
+++ b/tests/05-cqfd_init_flavor
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+. `dirname $0`/jtest.inc "$1"
+cqfd="$TDIR/.cqfd/cqfd"
+flavor="foo"
+
+cd $TDIR/
+
+temp_dir=".cqfd/`mktemp -d`"
+cqfdrc_old=`mktemp`
+cp .cqfdrc $cqfdrc_old
+sed -i -e "s/\[foo\]/\[foo\]\ndistro='centos'/" .cqfdrc
+
+jtest_prepare "cqfd init using '$flavor' flavor"
+if $cqfd -b $flavor init &&
+   $cqfd -b $flavor run "grep '^NAME=' /etc/*release" | grep 'NAME="CentOS Linux"'; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
+mv $cqfdrc_old .cqfdrc
+
+jtest_prepare "cqfd init without flavor"
+if $cqfd init &&
+   $cqfd run "grep '^NAME=' /etc/*release" | grep 'NAME="Ubuntu"'; then
+	jtest_result pass
+else
+	jtest_result fail
+fi

--- a/tests/05-cqfd_init_flavor
+++ b/tests/05-cqfd_init_flavor
@@ -6,24 +6,23 @@ flavor="foo"
 
 cd $TDIR/
 
-temp_dir=".cqfd/`mktemp -d`"
 cqfdrc_old=`mktemp`
-cp .cqfdrc $cqfdrc_old
-sed -i -e "s/\[foo\]/\[foo\]\ndistro='centos'/" .cqfdrc
+cp -f .cqfdrc $cqfdrc_old
+sed -i -e "s/\[foo\]/[foo]\ndistro='centos'/" .cqfdrc
 
 jtest_prepare "cqfd init using '$flavor' flavor"
 if $cqfd -b $flavor init &&
-   $cqfd -b $flavor run "grep '^NAME=' /etc/*release" | grep 'NAME="CentOS Linux"'; then
+   $cqfd -b $flavor run "grep '^NAME=' /etc/*release" | grep -q 'NAME="CentOS Linux"'; then
 	jtest_result pass
 else
 	jtest_result fail
 fi
 
-mv $cqfdrc_old .cqfdrc
+mv -f $cqfdrc_old .cqfdrc
 
 jtest_prepare "cqfd init without flavor"
 if $cqfd init &&
-   $cqfd run "grep '^NAME=' /etc/*release" | grep 'NAME="Ubuntu"'; then
+   $cqfd run "grep '^NAME=' /etc/*release" | grep -q 'NAME="Ubuntu"'; then
 	jtest_result pass
 else
 	jtest_result fail


### PR DESCRIPTION
Currently the `init' command build an image without the flavor.