### PR TITLE
cqfd: add quiet mode option -q

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -31,6 +31,7 @@ Usage: $PROGNAME [OPTION ARGUMENT] [COMMAND] [ARGUMENTS]
 Options:
     -f <file>           Use file as config file (default .cqfdrc).
     -b <flavor_name>    Target a specific build flavor.
+    -q                  Turn on quiet mode
     -h or --help        Show this help text.
 
 Commands:
@@ -101,7 +102,7 @@ docker_build() {
 	if [ ! -f $dockerfile ]; then
 		die "no Dockerfile found at location $dockerfile"
 	fi
-	docker build -q -t "$docker_img_name" `dirname $dockerfile`
+	docker build ${quiet:+-q} -t "$docker_img_name" `dirname $dockerfile`
 }
 
 # docker_run() - run command in configured container
@@ -265,6 +266,9 @@ while [ $# -gt 0 ]; do
 	-f)
 		shift
 		cqfdrc="$1"
+		;;
+	-q)
+		quiet=true
 		;;
 	run|release)
 		[ "$1" = "release" ] && make_archive=1

--- a/tests/01-cqfd_init
+++ b/tests/01-cqfd_init
@@ -31,6 +31,10 @@ fi
 #restore cqfdrc
 mv $cqfdrc_old .cqfdrc
 
-#restore docker image to run on
-$TDIR/.cqfd/cqfd init
 
+jtest_prepare "run cqfd init with original Dockerfile in quiet mode"
+if ! $TDIR/.cqfd/cqfd -q init | grep -E "^sha256:"; then
+	jtest_result fail
+else
+	jtest_result pass
+fi


### PR DESCRIPTION
Building a docker image may takes a while.

When cqfd init is run, docker is turned to quiet mode and cqfd does not
display any activity. User may think the cqfd process is get stuck.

This patch adds the support for the quiet mode to cqfd, which propagates
the quiet to mode to docker if the option -q is set.

Now:

	$ cqfd init

will display output from docker build, while:

	$ cqfd -q init

will turn docker build into quiet mode and display nothing.