### PR TITLE
cqfd: simplify parsing for multi-line

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -73,8 +73,7 @@ cfg_parser() {
 	ini=( ${ini[*]/\ =\ /=} )   # remove anything with a space around =
 	ini=( ${ini[*]/#\\[/\}$'\n'cfg.section.} ) # set section prefix
 	ini=( ${ini[*]/%\\]/ \(} )  # convert text2function (1)
-	ini=( ${ini[*]/=/=\( } )    # convert item to array
-	ini=( ${ini[*]/%/ \)} )     # close array parenthesis
+	ini=( ${ini[*]/%\(/ \( \)} ) # close array parenthesis
 	ini=( ${ini[*]/%\\ \)/ \\} ) # the multiline trick
 	ini=( ${ini[*]/%\( \)/\(\) \{} ) # convert text2function (2)
 	ini=( ${ini[*]/%\} \)/\}} ) # remove extra parenthesis


### PR DESCRIPTION
The ini-to-shell function is a nice but complicated trick.

It plays with bash arrays to translate an ini-style file into shell
scripting.

In this way, the following ini section

	[build]
	command='configure --enable-debug --extra-cflags=-I/usr/include && \
        	--extra-ldflags=-L/usr/lib && \
        	make'

is translated into the following shell

	cfg.section.build () {
	command=( 'configure --enable-debug --extra-cflags=-I/usr/include &&  \
        	--extra-ldflags=( -L/usr/lib &&  \
		make' )
	}

which is syntactically invalid due to the presence of a '=' character
in the second line of the command property.

The fault is a consequence of this instruction

	ini=( ${ini[*]/=/=\( } ) # convert item to array

which converts every first '=' of every line into '=( '. The trick
consists in making every values of ini properties a bash array.

We do not need the values to be an array. We can deal with scalar too.

This patch removes the translation of values into arrays, and thus
widely simplify the code understanding.

It results in the following shell

	cfg.section.build  () {
	command='configure --enable-debug --extra-cflags=-I/usr/include && \
	        --extra-ldflags=-L/usr/lib && \
	        make'
	}

which is syntactically correct.

This fix #11.