### PR TITLE
Fix tests

### DIFF
--- a/tests/00-setup
+++ b/tests/00-setup
@@ -11,6 +11,8 @@ cp -a test_data/. $TDIR/.
 cd $TDIR/
 if $TDIR/.cqfd/cqfd init; then
 	jtest_result fail
+else
+	jtest_result pass
 fi
 
 jtest_prepare "create an empty cqfdrc"
@@ -18,6 +20,8 @@ jtest_prepare "create an empty cqfdrc"
 touch $TDIR/.cqfdrc
 if $TDIR/.cqfd/cqfd init; then
 	jtest_result fail
+else
+	jtest_result pass
 fi
 
 jtest_prepare "create an incomplete cqfdrc"
@@ -25,8 +29,8 @@ jtest_prepare "create an incomplete cqfdrc"
 echo '[project]' >$TDIR/.cqfdrc
 if $TDIR/.cqfd/cqfd init; then
 	jtest_result fail
+else
+	jtest_result pass
 fi
-
-jtest_result pass
 
 cat $TDIR/cqfdrc-test >$TDIR/.cqfdrc

--- a/tests/01-cqfd_init
+++ b/tests/01-cqfd_init
@@ -12,7 +12,7 @@ jtest_result pass
 cqfdrc_old=`mktemp`
 jtest_prepare "init with a nonexisting dockerfile shall fail"
 cp -f .cqfdrc $cqfdrc_old
-sed -i -e "s/\[build\]/\[build\]\ndistro='thisshouldfail'/" .cqfdrc
+sed -i -e "s/\[build\]/[build]\ndistro='thisshouldfail'/" .cqfdrc
 if $TDIR/.cqfd/cqfd init; then
 	jtest_result fail
 else

--- a/tests/01-cqfd_init
+++ b/tests/01-cqfd_init
@@ -2,12 +2,15 @@
 
 . `dirname $0`/jtest.inc "$1"
 
-jtest_prepare "run cqfd init"
-
 cd $TDIR/
-$TDIR/.cqfd/cqfd init
 
-jtest_result pass
+jtest_prepare "run cqfd init"
+if $TDIR/.cqfd/cqfd init; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
 
 cqfdrc_old=`mktemp`
 jtest_prepare "init with a nonexisting dockerfile shall fail"

--- a/tests/01-cqfd_init
+++ b/tests/01-cqfd_init
@@ -11,7 +11,7 @@ jtest_result pass
 
 cqfdrc_old=`mktemp`
 jtest_prepare "init with a nonexisting dockerfile shall fail"
-cp .cqfdrc $cqfdrc_old
+cp -f .cqfdrc $cqfdrc_old
 sed -i -e "s/\[build\]/\[build\]\ndistro='thisshouldfail'/" .cqfdrc
 if $TDIR/.cqfd/cqfd init; then
 	jtest_result fail
@@ -28,7 +28,7 @@ else
 	jtest_result fail
 fi
 #restore cqfdrc
-mv $cqfdrc_old .cqfdrc
+mv -f $cqfdrc_old .cqfdrc
 
 #restore docker image to run on
 $TDIR/.cqfd/cqfd init

--- a/tests/01-cqfd_init
+++ b/tests/01-cqfd_init
@@ -9,7 +9,6 @@ $TDIR/.cqfd/cqfd init
 
 jtest_result pass
 
-temp_dir=".cqfd/`mktemp -d`"
 cqfdrc_old=`mktemp`
 jtest_prepare "init with a nonexisting dockerfile shall fail"
 cp .cqfdrc $cqfdrc_old

--- a/tests/03-cqfd_help
+++ b/tests/03-cqfd_help
@@ -8,6 +8,8 @@ TEST=`mktemp`
 if ! $TDIR/.cqfd/cqfd help >$TEST; then
 	jtest_result fail
 	rm -f $TEST
+else
+	jtest_result pass
 fi
 
 jtest_prepare "cqfd help shall produce an help message"

--- a/tests/05-cqfd_run
+++ b/tests/05-cqfd_run
@@ -4,7 +4,7 @@
 cqfd="$TDIR/.cqfd/cqfd"
 test_file="build.txt"
 
-cd $TDIR
+cd $TDIR/
 
 # Here we test cqfd run, which is also invoked without any argument
 for i in 0 1; do

--- a/tests/05-cqfd_run
+++ b/tests/05-cqfd_run
@@ -10,20 +10,19 @@ cd $TDIR
 for i in 0 1; do
 	# Data set shall produce build.txt:
 
-	jtest_prepare "run cqfd without any argument, pass $i"
+	jtest_log info "run cqfd without any argument, pass $i"
 
 	if [ -f "$test_file" ]; then
 		jtest_log fatal "$test_file already present before test"
-		jtest_result fail
 		rm -f $test_file
 		continue
 	fi
 
 	if [ "$i" = "1" ]; then
-		jtest_log info "running cqfd run for pass $f"
+		jtest_prepare "running cqfd run for pass $f"
 		$cqfd run
 	else
-		jtest_log info "running cqfd run without argument for pass $f"
+		jtest_prepare "running cqfd run without argument for pass $f"
 		$cqfd
 	fi
 

--- a/tests/05-cqfd_run_command
+++ b/tests/05-cqfd_run_command
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 . `dirname $0`/jtest.inc "$1"
-test_file="file.$RANDOM"
 cqfd="$TDIR/.cqfd/cqfd"
+test_file="file.$RANDOM"
 
 cd $TDIR/
 

--- a/tests/05-cqfd_run_command
+++ b/tests/05-cqfd_run_command
@@ -12,11 +12,10 @@ cd $TDIR/
 for i in 0 1; do
 	# Data set shall produce build.txt:
 
-	jtest_prepare "run cqfd hout additional argument, pass $i"
+	jtest_log info "run cqfd hout additional argument, pass $i"
 
 	if [ -f "$test_file" ]; then
 		jtest_log fatal "$test_file already present before test"
-		jtest_result fail
 		rm -f $test_file
 		continue
 	fi

--- a/tests/05-cqfd_run_config
+++ b/tests/05-cqfd_run_config
@@ -18,7 +18,7 @@ mv .cqfdrc $confdir/mycqfdrc
 touch .cqfdrc
 
 for i in 0 1 2 3; do
-	jtest_prepare "run cqfd with a non default file: $confdir/mycqfdrc, pass $i"
+	jtest_log info "run cqfd with a non default file: $confdir/mycqfdrc, pass $i"
 
 	case $i in
 		0)

--- a/tests/05-cqfd_run_extra_env
+++ b/tests/05-cqfd_run_extra_env
@@ -3,7 +3,7 @@
 . `dirname $0`/jtest.inc "$1"
 cqfd="$TDIR/.cqfd/cqfd"
 
-cd $TDIR
+cd $TDIR/
 
 jtest_prepare "run cqfd with extra environment variables"
 

--- a/tests/05-cqfd_run_extra_hosts
+++ b/tests/05-cqfd_run_extra_hosts
@@ -4,7 +4,7 @@
 cqfd="$TDIR/.cqfd/cqfd"
 getent_cmd="getent hosts 1.2.3.4"
 
-cd $TDIR
+cd $TDIR/
 
 # First pass: no cqfd_extra_hosts
 # Second pass: cqfd_extra_hosts defined

--- a/tests/05-cqfd_run_flavor
+++ b/tests/05-cqfd_run_flavor
@@ -10,7 +10,7 @@ cd $TDIR/
 # Second pass: override flavor build with an additional command
 
 for i in 0 1; do
-	jtest_prepare "run cqfd with a given '$flavor' flavor, pass $i"
+	jtest_log info "run cqfd with a given '$flavor' flavor, pass $i"
 
 	if [ "$i" = "0" ]; then
 		test_file=$flavor

--- a/tests/06-cqfd_release
+++ b/tests/06-cqfd_release
@@ -18,8 +18,6 @@ fi
 echo "files=build.txt" >>.cqfdrc
 
 jtest_prepare "cqfd release now with a files parameter"
-$cqfd release
-
 if $cqfd release; then
 	jtest_result pass
 else

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,8 +1,8 @@
 .PHONY: tests
 
 tests:
-	$(eval TDIR=$(shell mktemp -d))
-	for f in [0-9][0-9]*; do \
+	@$(eval TDIR=$(shell mktemp -d))
+	@for f in [0-9][0-9]*; do \
 		if [ -x "$$f" ]; then \
 			./$$f $(TDIR) || failed=1; \
 		fi; \


### PR DESCRIPTION
I did some minor changes into tests. It mostly makes the output nicer.

The following traces disapear
```
for f in [0-9][0-9]*; do \
	if [ -x "$f" ]; then \
		./$f /tmp/tmp.agEEVC9qHT || failed=1; \
	fi; \
done; \
if [ -f /tmp/tmp.agEEVC9qHT/.jtest_results ]; then \
	echo " --- Test results ---"; \
	cat "/tmp/tmp.agEEVC9qHT"/.jtest_results; \
	echo " --------------------"; \
fi; \
if echo /tmp/tmp.agEEVC9qHT | grep -q "/tmp/tmp\.[a-zA-Z]"; then \
	rm -rf /tmp/tmp.agEEVC9qHT; \
fi; \
if [ "$failed" = "1" ]; then \
	echo "Failures occured"; \
	exit 1; \
fi
```

while those missing traces are now displayed (for result)

```
|pass|create a test skeleton in temporary directory
|pass|create an empty cqfdrc
(...)
|pass|cqfd help shall exit normally
```

and those one

```
|pass|run cqfd without any argument, pass 0
|pass|run cqfd without any argument, pass 1
```

are modified into

```
|pass|running cqfd run without argument for pass 
|pass|running cqfd run for pass 
```