### PR TITLE
cqfd: fix non unique user-id

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -157,7 +157,7 @@ docker_run() {
 	       ${SSH_AUTH_SOCK:+ -e SSH_AUTH_SOCK=/home/builder/.sockets/ssh} \
 	       $docker_img_name \
 	       /bin/bash -c "groupadd -og $GROUPS -f builders && \
-	       useradd -s /bin/bash -u $UID -g $GROUPS builder && \
+	       useradd -s /bin/bash -ou $UID -g $GROUPS builder && \
 	       chown $UID:$GROUPS /home/builder && \
 	       su builder -p -c \"cd ~builder/src/ && $1\" 2>&1"
 }

--- a/tests/01-cqfd_init
+++ b/tests/01-cqfd_init
@@ -34,6 +34,18 @@ fi
 mv -f $cqfdrc_old .cqfdrc
 
 
+jtest_prepare "add dummy user and dummy group with same uid/gid"
+cat <<EOF >>.cqfd/docker/Dockerfile
+RUN groupadd -og $GROUPS -f dummy && \
+    useradd -s /bin/bash -ou $UID -g $GROUPS dummy
+EOF
+if $TDIR/.cqfd/cqfd init; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
+
 jtest_prepare "run cqfd init with original Dockerfile in quiet mode"
 if ! $TDIR/.cqfd/cqfd -q init | grep -E "^sha256:"; then
 	jtest_result fail


### PR DESCRIPTION
Under certain circumstances, our UID may be already taken by another
user into the container

	$ cqfd -d
	useradd: UID 1000 is not unique

Add the non-unique `-o' as it is already the case for groupadd.