### PR TITLE
Bash completion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for cqfd
 
-DESTDIR=/usr/local
+PREFIX?=/usr/local
 
 .PHONY: all help install uninstall tests
 
@@ -14,17 +14,17 @@ help:
 	@echo "   tests:     Run functional tests"
 
 install:
-	install -d $(DESTDIR)/bin
-	install -m 0755 cqfd $(DESTDIR)/bin/cqfd
-	install -d $(DESTDIR)/share/doc/cqfd
-	install -m 0644 AUTHORS CHANGELOG LICENSE README.md $(DESTDIR)/share/doc/cqfd/
-	install -d $(DESTDIR)/share/cqfd/samples
-	install -m 0644 samples/* $(DESTDIR)/share/cqfd/samples
+	install -d $(DESTDIR)$(PREFIX)/bin/
+	install -m 0755 cqfd $(DESTDIR)$(PREFIX)/bin/
+	install -d $(DESTDIR)$(PREFIX)/share/doc/cqfd/
+	install -m 0644 AUTHORS CHANGELOG LICENSE README.md $(DESTDIR)$(PREFIX)/share/doc/cqfd/
+	install -d $(DESTDIR)$(PREFIX)/share/cqfd/samples/
+	install -m 0644 samples/* $(DESTDIR)$(PREFIX)/share/cqfd/samples/
 
 uninstall:
-	rm -rf $(DESTDIR)/bin/cqfd \
-		$(DESTDIR)/share/doc/cqfd \
-		$(DESTDIR)/share/cqfd
+	rm -rf $(DESTDIR)$(PREFIX)/bin/cqfd \
+		$(DESTDIR)$(PREFIX)/share/doc/cqfd \
+		$(DESTDIR)$(PREFIX)/share/cqfd
 
 tests:
 	@make -C tests

--- a/Makefile
+++ b/Makefile
@@ -20,11 +20,20 @@ install:
 	install -m 0644 AUTHORS CHANGELOG LICENSE README.md $(DESTDIR)$(PREFIX)/share/doc/cqfd/
 	install -d $(DESTDIR)$(PREFIX)/share/cqfd/samples/
 	install -m 0644 samples/* $(DESTDIR)$(PREFIX)/share/cqfd/samples/
+	completionsdir=$$(pkg-config --variable=completionsdir bash-completion); \
+	if [ -n "$$completionsdir" ]; then \
+		install -d $(DESTDIR)$$completionsdir/; \
+		install -m 644 bash-completion $(DESTDIR)$$completionsdir/cqfd; \
+	fi
 
 uninstall:
 	rm -rf $(DESTDIR)$(PREFIX)/bin/cqfd \
 		$(DESTDIR)$(PREFIX)/share/doc/cqfd \
 		$(DESTDIR)$(PREFIX)/share/cqfd
+	completionsdir=$$(pkg-config --variable=completionsdir bash-completion); \
+	if [ -n "$$completionsdir" ]; then \
+		rm -rf $(DESTDIR)$$completionsdir/cqfd; \
+	fi
 
 tests:
 	@make -C tests

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ By default, cqfd will generate a release tarball named
 org-name.tar.xz, where 'org' and 'name' come from the project's
 configuration keys.
 
-flavors: the list of build flavors (see below). Each flavor has its
+``flavors``: the list of build flavors (see below). Each flavor has its
 own command just like build.command.
 
 ### Using build flavors ###

--- a/README.md
+++ b/README.md
@@ -206,8 +206,13 @@ The cqfd script can be installed system-wide.
 Install or remove the script and its resources:
 
     $ make install
-    $ make DESTDIR=/usr install
     $ make uninstall
+
+Makefile honors both **PREFIX** (__/usr/local__) and **DESTDIR** (__[empty]__)
+variables:
+
+    $ make install PREFIX=/opt
+    $ make install PREFIX=/usr DESTDIR=package
 
 ## Testing cqfd (for developers) ##
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ flavor's name.
 A flavor will typically redefine the keys of the build section:
 command, files, archive.
 
+Flavors from a `.cqfdrc` file can be listed using the `flavors` argument.
+
 ### Environment variables ###
 
 The following environment variables are supported by cqfd to provide

--- a/bash-completion
+++ b/bash-completion
@@ -1,0 +1,62 @@
+#!/bin/sh
+#
+# Copyright (C) 2017 Savoir-faire Linux, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+_cqfd() {
+	local cur prev words cword
+	_init_completion || return
+
+	case $prev in
+	-f)
+		_filedir
+		return
+		;;
+	-b)
+		local flavors cqfdrc=.cqfdrc
+		# before we scan for flavors, see if a cqfdrc name was
+		# specified with -f
+		for (( i=0; i < ${#words[@]}; i++ )); do
+			if [[ ${words[i]} == -f ]]; then
+				# eval for tilde expansion
+				eval cqfdrc=( "${words[i+1]}" )
+			fi
+		done
+
+		if [ -e "$cqfdrc" ]; then
+			flavors=$(cqfd -f $cqfdrc flavors)
+			COMPREPLY=( $(compgen -W "$flavors" -- "$cur") )
+		fi
+		return
+		;;
+	init|flavors|release|help)
+		return
+		;;
+	run)
+		COMPREPLY=( $(compgen -c "$cur") )
+		return
+		;;
+	esac
+
+	local opts="-f -b -q -h --help"
+	if [[ "$cur" == -* ]]; then
+		COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+		return
+	fi
+
+	local long_opts="init flavors run release help"
+	COMPREPLY=( $(compgen -W "$long_opts $opts" -- "$cur") )
+} &&
+complete -F _cqfd cqfd

--- a/cqfd
+++ b/cqfd
@@ -36,6 +36,7 @@ Options:
 
 Commands:
     init     Initialize project build container
+    flavors  List flavors from config file to stdout
     run      Run argument(s) inside build container
     release  Run argument(s) and release software
     help     Show this help text
@@ -257,6 +258,11 @@ while [ $# -gt 0 ]; do
 		config_load $flavor
 		docker_build
 		exit $?
+		;;
+	flavors)
+		config_load
+		echo $flavors
+		exit 0
 		;;
 	-b)
 		shift


### PR DESCRIPTION
**Auto-completion** makes life easier. Lets start by entering *cqfd* and then enter ```TAB```.

	$ cqfd [TAB]
	-b       -f       -h       help     --help   init     -q       release
	run

Every *argument* (*options* and *functions*) handled by *cqfd* are *auto-completed*.

Now, enter a *dash* ```-``` then ```TAB```.

	$ cqfd -[TAB]
	-b      -f      -h      --help  -q

This time, only *options* handled by *cqfd* are *auto-completed*.

Lets start with *flavors*. Enter ```-b``` then ```TAB```.

	$ cqfd -b [TAB]
	centos  ubuntu

Every *flavors* from ```.cqfdrc``` resource file are *auto-completed*.

Select ```ubuntu``` for example.

Lets change the resource file. Enter ```-f``` then ```TAB```.

	$ cqfd -b ubuntu -f [TAB]
	AUTHORS              CHANGELOG            cqfd*                .cqfd/
	cqfd.1.adoc          .cqfdrc              cqfdrc.5.adoc
	.cqfdrc-alternative  .cqfdrc-empty        .cqfdrc-fail         .git/
	.gitignore           .gitreview           _install/
	LICENSE              Makefile             README.md            samples/
	tests/

Every *files* and *directories* from current directory are *auto-completed*.

Select alternative *resource file* ```.cqfdrc-alternative```. Then re-enter ```-b``` and ```[TAB]``` to pick up a *flavor*.

	$ cqfd -b ubuntu -f .cqfdrc-alternative -b [TAB]
	alpine   busybox

*Flavors* are updated according to the specified *resource file*. Select ```alpine```.

Try the empty *resource file* ```/dev/null``` using ```-f```, and select for a flavor

	$ cqfd -b ubuntu -f .cqfdrc-alternative -b alpine -f /dev/null -b [TAB]

Absolutely nothing is *auto-completed*; because ```/dev/null``` has no *flavors*.

Try the *quiet* option ```-q``` which does not *required* argument.

	$ cqfd -b ubuntu -f .cqfdrc-alternative -b alpine -q
	-b       -f       -h       help     --help   init     -q       release
	run

Again, every *arguments* (*options* and *functions*) handled by *cqfd* are *auto-completed*.

Enter ```init```, ```release``` and ```help``` functions followed by a ```TAB```.

	$ cqfd -b ubuntu -f .cqfdrc-alternative -b alpine -q i[TAB]
	$ cqfd -b ubuntu -f .cqfdrc-alternative -b alpine -q init [TAB]

	$ cqfd -b ubuntu -f .cqfdrc-alternative -b alpine -q re[TAB]
	$ cqfd -b ubuntu -f .cqfdrc-alternative -b alpine -q release [TAB]

	$ cqfd -b ubuntu -f .cqfdrc-alternative -b alpine -q h[TAB]
	$ cqfd -b ubuntu -f .cqfdrc-alternative -b alpine -q help [TAB]

They are *end-point*: nothing is *auto-completed*.

Conclude with ```run``` function followed by a ```[TAB]```

	$ cqfd -b ubuntu -f .cqfdrc-alternative -b alpine -q ru[TAB]
	$ cqfd -b ubuntu -f .cqfdrc-alternative -b alpine -q run [TAB]
	AUTHORS              CHANGELOG            cqfd*                .cqfd/
	cqfd.1.adoc          .cqfdrc              cqfdrc.5.adoc
	.cqfdrc-alternative  .cqfdrc-empty        .cqfdrc-fail         .git/
	.gitignore           .gitreview           _install/
	LICENSE              Makefile             README.md            samples/
	tests/

Every *files* and *directories* from current directory are *auto-completed*.