### PR TITLE
cqfd: don't use a log driver

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -149,6 +149,7 @@ docker_run() {
 	docker run --privileged -v "$PWD":/home/builder/src \
 	       -v ~/.ssh:/home/builder/.ssh \
 	       --rm \
+	       --log-driver=none \
 	       $extravol \
 	       $extrahosts \
 	       $extraenv \


### PR DESCRIPTION
Get rid of it as the default docker configuration will most likely
result in cqfd's output be logged to journald/syslog, which will fill
with tons of blob data.