### PR TITLE
Sets HOME environment variable to builder user home directory 

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -167,12 +167,9 @@ docker_run() {
 	# was explicitely set via CQFD_EXTRA_ENV
 	local home_env_var
 	home_env_var="-e HOME=/home/builder"
-	if [ -n "$extraenv" ]; then
-		if `echo $extraenv | grep "HOME=" 1>/dev/null 2>&1`
-		then
-			home_env_var=""
-		fi
-	fi
+	if echo "$extraenv" | grep -q "[[:blank:]]HOME="; then
+        home_env_var=""
+    fi
 
 	docker run --privileged -v "$PWD":/home/builder/src \
 	       -v ~/.ssh:/home/builder/.ssh \

--- a/cqfd
+++ b/cqfd
@@ -163,6 +163,17 @@ docker_run() {
 		done
 	fi
 
+	# Set HOME variable for the builder user, except if it
+	# was explicitely set via CQFD_EXTRA_ENV
+	local home_env_var
+	home_env_var="-e HOME=/home/builder"
+	if [ -n "$extraenv" ]; then
+		if `echo $extraenv | grep "HOME=" 1>/dev/null 2>&1`
+		then
+			home_env_var=""
+		fi
+	fi
+
 	docker run --privileged -v "$PWD":/home/builder/src \
 	       -v ~/.ssh:/home/builder/.ssh \
 	       --rm \
@@ -171,6 +182,7 @@ docker_run() {
 	       $extrahosts \
 	       $extraenv \
 	       $extraports \
+	       $home_env_var \
 	       $interactive_options \
 	       ${SSH_AUTH_SOCK:+ -v $SSH_AUTH_SOCK:/home/builder/.sockets/ssh} \
 	       ${SSH_AUTH_SOCK:+ -e SSH_AUTH_SOCK=/home/builder/.sockets/ssh} \

--- a/tests/05-cqfd_run_home_env_var
+++ b/tests/05-cqfd_run_home_env_var
@@ -34,3 +34,36 @@ if [ "$result" = "$val1 $val2" ]; then
 else
 	jtest_result fail
 fi
+
+################################################################################
+# 'cqfd run' does not override HOME environment when it is the only entry in
+# CQFD_EXTRA_ENV
+################################################################################
+jtest_prepare "run cqfd does not override HOME environment when it is the only entry in CQFD_EXTRA_ENV"
+val1="value-$RANDOM"
+
+result=$(CQFD_EXTRA_ENV="HOME=$val1" $cqfd run 'echo -n $FOO $HOME' | grep value)
+
+if [ "$result" = "$val1" ]; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
+################################################################################
+# 'cqfd run' does not confuse JAVA_HOME and the like with HOME when set via
+# CQFD_EXTRA_ENV
+################################################################################
+jtest_prepare "run cqfd 'cqfd run' does not confuse JAVA_HOME and the like with HOME"
+val1="value-$RANDOM"
+val2="value-$RANDOM"
+
+result=$(CQFD_EXTRA_ENV="JAVA_HOME=$val1 HOME=$val2" $cqfd run 'echo -n $JAVA_HOME $HOME' | grep value)
+
+if [ "$result" = "$val1 $val2" ]; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
+

--- a/tests/05-cqfd_run_home_env_var
+++ b/tests/05-cqfd_run_home_env_var
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+. `dirname $0`/jtest.inc "$1"
+cqfd="$TDIR/.cqfd/cqfd"
+
+cd $TDIR/
+
+
+################################################################################
+# 'cqfd run' sets HOME environment variable for builder user
+################################################################################
+jtest_prepare "run cqfd sets HOME environment variable for builder user"
+result=$($cqfd run 'echo -n $HOME')
+
+if [ "$result" = "/home/builder" ]; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
+
+################################################################################
+# 'cqfd run' does not override HOME environment explicitely set via
+# CQFD_EXTRA_ENV
+################################################################################
+jtest_prepare "run cqfd does not override HOME environment explicitely set via CQFD_EXTRA_ENV"
+val1="value-$RANDOM"
+val2="value-$RANDOM"
+
+result=$(CQFD_EXTRA_ENV="FOO=$val1 HOME=$val2" $cqfd run 'echo -n $FOO $HOME' | grep value)
+
+if [ "$result" = "$val1 $val2" ]; then
+	jtest_result pass
+else
+	jtest_result fail
+fi


### PR DESCRIPTION
(HOME=/home/builder)

If CQFD_EXTRA_ENV contains an explicit HOME entry, the explicit value is used.

The variable is passed to docker-run via the -e mechanism.

Fixes issue-44.