### PR TITLE
add CQFD_EXTRA_RUN_ARGS option

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,17 +157,10 @@ The following environment variables are supported by cqfd to provide
 the user with extra flexibility during his day-to-day development
 tasks:
 
-``CQFD_EXTRA_VOLUMES``: A space-separated list of additional volume
-mappings to be configured inside the started container. Format is the
-same as (and passed to) docker-run’s -v option.
-
-``CQFD_EXTRA_HOSTS``: A space-separated list of additional host
-mappings to be configured inside the started container. Format is the
-same as (and passed to) docker-run’s --add-host option.
-
-``CQFD_EXTRA_ENV``: A space-separated list of additional environment
-variables to be passed to the started container. Format is the
-same as (and passed to) docker-run’s -e option.
+``CQFD_EXTRA_RUN_ARGS``: A space-separated list of additional
+docker-run options to be append to the starting container.
+Format is the same as (and passed to) docker-run’s options.
+See 'docker run --help'.
 
 ### Other command-line options ###
 

--- a/cqfd
+++ b/cqfd
@@ -130,54 +130,39 @@ docker_run() {
 		interactive_options="-ti"
 	fi
 
-	# The user may set the CQFD_EXTRA_VOLUMES environment variable
-	# to map custom volumes inside his development container.
+	# Display a warning message if using no more supported options
 	if [ -n "$CQFD_EXTRA_VOLUMES" ]; then
-		local map extravol
-		for map in $CQFD_EXTRA_VOLUMES; do
-			extravol+="-v $map "
-		done
+		echo 'Warning: CQFD_EXTRA_VOLUMES is no more supported, use
+		CQFD_EXTRA_RUN_ARGS="-v <local_dir>:<container_dir>"'
 	fi
-
 	if [ -n "$CQFD_EXTRA_HOSTS" ]; then
-		local map extrahosts
-		for map in $CQFD_EXTRA_HOSTS; do
-			extrahosts+="--add-host $map "
-		done
+		echo 'Warning: CQFD_EXTRA_HOSTS is no more supported, use
+		CQFD_EXTRA_RUN_ARGS="--add-host <hostname>:<IP_address>"'
 	fi
-
-	# CQFD_EXTRA_ENV is a space-separated list like VAR=value
 	if [ -n "$CQFD_EXTRA_ENV" ]; then
-		local map extraenv
-		for map in $CQFD_EXTRA_ENV; do
-			extraenv+="-e $map "
-		done
+		echo 'Warning: CQFD_EXTRA_ENV is no more supported, use
+		CQFD_EXTRA_RUN_ARGS="-e <var_name>=<value>"'
+	fi
+	if [ -n "$CQFD_EXTRA_PORTS" ]; then
+		echo 'Warning: CQFD_EXTRA_PORTS is no more supported, use
+		CQFD_EXTRA_RUN_ARGS="-p <host_port>:<docker_port>"'
 	fi
 
-	# CQFD_EXTRA_PORTS allows to publish container's ports to
-	# the host, in a space-separated HOST:CONTAINER list.
-	if [ -n "$CQFD_EXTRA_PORTS" ]; then
-		local port extraports
-		for port in $CQFD_EXTRA_PORTS; do
-			extraports+="-p $port "
-		done
-	fi
+	# The user may set the CQFD_EXTRA_RUN_ARGS environment variables
+	# to pass custom run arguments to his development container.
 
 	# Set HOME variable for the builder user, except if it was
-	# explicitely set via CQFD_EXTRA_ENV
+	# explicitely set via CQFD_EXTRA_RUN_ARGS
 	local home_env_var="-e HOME=/home/builder"
-	if echo "$extraenv" | grep -q "[[:blank:]]HOME="; then
-		home_env_var=""
+	if echo "$CQFD_EXTRA_RUN_ARGS" | egrep -q "(-e[[:blank:]]*|--env[[:blank:]]+)HOME="; then
+		local home_env_var=""
 	fi
 
 	docker run --privileged -v "$PWD":/home/builder/src \
 	       -v ~/.ssh:/home/builder/.ssh \
 	       --rm \
 	       --log-driver=none \
-	       $extravol \
-	       $extrahosts \
-	       $extraenv \
-	       $extraports \
+	       $CQFD_EXTRA_RUN_ARGS \
 	       $home_env_var \
 	       $interactive_options \
 	       ${SSH_AUTH_SOCK:+ -v $SSH_AUTH_SOCK:/home/builder/.sockets/ssh} \

--- a/tests/05-cqfd_run_extra_env
+++ b/tests/05-cqfd_run_extra_env
@@ -7,14 +7,15 @@ cd $TDIR/
 
 ################################################################################
 # 'cqfd run' passes environment variables to the container when using
-# CQFD_EXTRA_ENV
+# CQFD_EXTRA_RUN_ARGS
 ################################################################################
 jtest_prepare "run cqfd with extra environment variables"
 
 val1="value-$RANDOM"
 val2="value-$RANDOM"
 
-result=$(CQFD_EXTRA_ENV="FOO=$val1 BAR=$val2" $cqfd run 'echo -n $FOO $BAR' | grep value)
+result=$(CQFD_EXTRA_RUN_ARGS="-e FOO=$val1 -e BAR=$val2" \
+	$cqfd run 'echo -n $FOO $BAR' | grep value)
 
 if [ "$result" = "$val1 $val2" ]; then
     jtest_result pass

--- a/tests/05-cqfd_run_extra_hosts
+++ b/tests/05-cqfd_run_extra_hosts
@@ -6,8 +6,8 @@ getent_cmd="getent hosts 1.2.3.4"
 
 cd $TDIR/
 
-# First pass: no cqfd_extra_hosts
-# Second pass: cqfd_extra_hosts defined
+# First pass: no extra hosts
+# Second pass: extra hosts defined with CQFD_EXTRA_RUN_ARGS
 
 for i in 0 1; do
     if [ "$i" = "0" ]; then
@@ -23,7 +23,8 @@ for i in 0 1; do
 
     if [ "$i" = "1" ]; then
         jtest_prepare "run cqfd with extra hosts, pass $i"
-        output=$(CQFD_EXTRA_HOSTS="testhost:1.2.3.4" $cqfd run $getent_cmd ; exit 0)
+        output=$(CQFD_EXTRA_RUN_ARGS="--add-host testhost:1.2.3.4" \
+			$cqfd run $getent_cmd ; exit 0)
 
         if [[ "$output" == *"1.2.3.4"*"testhost"* ]]; then
             jtest_result pass

--- a/tests/05-cqfd_run_home_env_var
+++ b/tests/05-cqfd_run_home_env_var
@@ -21,13 +21,15 @@ fi
 
 ################################################################################
 # 'cqfd run' does not override HOME environment explicitely set via
-# CQFD_EXTRA_ENV
+# CQFD_EXTRA_RUN_ARGS
 ################################################################################
-jtest_prepare "run cqfd does not override HOME environment explicitely set via CQFD_EXTRA_ENV"
+jtest_prepare "run cqfd does not override HOME environment explicitely set \
+	via CQFD_EXTRA_RUN_ARGS"
 val1="value-$RANDOM"
 val2="value-$RANDOM"
 
-result=$(CQFD_EXTRA_ENV="FOO=$val1 HOME=$val2" $cqfd run 'echo -n $FOO $HOME' | grep value)
+result=$(CQFD_EXTRA_RUN_ARGS="-e FOO=$val1 -e HOME=$val2" \
+	$cqfd run 'echo -n $FOO $HOME' | grep value)
 
 if [ "$result" = "$val1 $val2" ]; then
 	jtest_result pass
@@ -37,12 +39,14 @@ fi
 
 ################################################################################
 # 'cqfd run' does not override HOME environment when it is the only entry in
-# CQFD_EXTRA_ENV
+# CQFD_EXTRA_RUN_ARGS
 ################################################################################
-jtest_prepare "run cqfd does not override HOME environment when it is the only entry in CQFD_EXTRA_ENV"
+jtest_prepare "run cqfd does not override HOME environment when it is the \
+	only entry in CQFD_EXTRA_RUN_ARGS"
 val1="value-$RANDOM"
 
-result=$(CQFD_EXTRA_ENV="HOME=$val1" $cqfd run 'echo -n $FOO $HOME' | grep value)
+result=$(CQFD_EXTRA_RUN_ARGS="-e HOME=$val1" \
+	$cqfd run 'echo -n $FOO $HOME' | grep value)
 
 if [ "$result" = "$val1" ]; then
 	jtest_result pass
@@ -52,13 +56,15 @@ fi
 
 ################################################################################
 # 'cqfd run' does not confuse JAVA_HOME and the like with HOME when set via
-# CQFD_EXTRA_ENV
+# CQFD_EXTRA_RUN_ARGS
 ################################################################################
-jtest_prepare "run cqfd 'cqfd run' does not confuse JAVA_HOME and the like with HOME"
+jtest_prepare "run cqfd 'cqfd run' does not confuse JAVA_HOME and the like \
+	with HOME"
 val1="value-$RANDOM"
 val2="value-$RANDOM"
 
-result=$(CQFD_EXTRA_ENV="JAVA_HOME=$val1 HOME=$val2" $cqfd run 'echo -n $JAVA_HOME $HOME' | grep value)
+result=$(CQFD_EXTRA_RUN_ARGS="-e JAVA_HOME=$val1 -e HOME=$val2" \
+	$cqfd run 'echo -n $JAVA_HOME $HOME' | grep value)
 
 if [ "$result" = "$val1 $val2" ]; then
 	jtest_result pass


### PR DESCRIPTION
To provide flexibility during day-to-day development tasks, the user may
set CQFD_EXTRA_RUN_ARGS to add extra options to cqfd docker run command.

This option turns useless following envrionnement variables but option
in parenthesis must be append in CQFD_EXTRA_RUN_ARGS:
* CQFD_EXTRA_VOLUMES (-v|--volume)
* CQFD_EXTRA_HOSTS   (--add-host)
* CQFD_EXTRA_ENV     (-e|--env)
* CQFD_EXTRA_PORTS   (-p|--publish)

Signed-off-by: Gilles DOFFE <gilles.doffe@savoirfairelinux.com>
