### PR TITLE
die on legacy option usage

### DIFF
--- a/.cqfd/ubuntu/Dockerfile
+++ b/.cqfd/ubuntu/Dockerfile
@@ -1,0 +1,4 @@
+FROM centos:7
+
+ENV LANG en_US.utf8
+ENV LC_ALL en_US.utf8

--- a/.cqfdrc
+++ b/.cqfdrc
@@ -1,0 +1,10 @@
+[project]
+org='sfl'
+name='cqfd'
+
+[build]
+distro=ubuntu
+command='echo Salut build'
+
+files='samples/D* tests/j* README.md te*'
+archive='%Po-%Pn_%D3-%Gh.tar.xz'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog for cqfd
 
+## Version 5.0.1 (2018-12-13)
+
+* Fix wrong user homedir in container when host user isn't in /home
+* Terminate cqfd in case a legacy CQFD_EXTRA_* variable is used.
+
 ## Version 5.0.0
 
 * Use semantic versioning

--- a/cqfd
+++ b/cqfd
@@ -174,12 +174,12 @@ docker_run() {
 	tmp_launcher=$(make_launcher)
 
 	docker run --privileged \
+	       $CQFD_EXTRA_RUN_ARGS \
+	       --rm \
+	       --log-driver=none \
 	       -v $tmp_launcher:/bin/cqfd_launch \
 	       -v ~/.ssh:$cqfd_user_home/.ssh \
 	       -v "$PWD":$cqfd_user_cwd \
-	       --rm \
-	       --log-driver=none \
-	       $CQFD_EXTRA_RUN_ARGS \
 	       $home_env_var \
 	       $interactive_options \
 	       ${SSH_AUTH_SOCK:+ -v $SSH_AUTH_SOCK:$cqfd_user_home/.sockets/ssh} \

--- a/cqfd
+++ b/cqfd
@@ -262,7 +262,7 @@ make_launcher()
 
 # create container user to match expected environment
 groupadd -og $GROUPS -f builders >/dev/null 2>&1
-useradd -s /bin/bash -ou $UID -g $GROUPS $cqfd_user >/dev/null 2>&1
+useradd -s /bin/bash -ou $UID -g $GROUPS -d "$cqfd_user_home" $cqfd_user >/dev/null 2>&1
 chown $UID:$GROUPS $cqfd_user_home
 
 # run the provided command in the working directory

--- a/cqfd
+++ b/cqfd
@@ -145,19 +145,19 @@ docker_run() {
 
 	# Display a warning message if using no more supported options
 	if [ -n "$CQFD_EXTRA_VOLUMES" ]; then
-		echo 'Warning: CQFD_EXTRA_VOLUMES is no more supported, use
+		die 'Warning: CQFD_EXTRA_VOLUMES is no more supported, use
 		CQFD_EXTRA_RUN_ARGS="-v <local_dir>:<container_dir>"'
 	fi
 	if [ -n "$CQFD_EXTRA_HOSTS" ]; then
-		echo 'Warning: CQFD_EXTRA_HOSTS is no more supported, use
+		die 'Warning: CQFD_EXTRA_HOSTS is no more supported, use
 		CQFD_EXTRA_RUN_ARGS="--add-host <hostname>:<IP_address>"'
 	fi
 	if [ -n "$CQFD_EXTRA_ENV" ]; then
-		echo 'Warning: CQFD_EXTRA_ENV is no more supported, use
+		die 'Warning: CQFD_EXTRA_ENV is no more supported, use
 		CQFD_EXTRA_RUN_ARGS="-e <var_name>=<value>"'
 	fi
 	if [ -n "$CQFD_EXTRA_PORTS" ]; then
-		echo 'Warning: CQFD_EXTRA_PORTS is no more supported, use
+		die 'Warning: CQFD_EXTRA_PORTS is no more supported, use
 		CQFD_EXTRA_RUN_ARGS="-p <host_port>:<docker_port>"'
 	fi
 

--- a/tests/05-cqfd_run_home_env_var
+++ b/tests/05-cqfd_run_home_env_var
@@ -68,3 +68,17 @@ if [ "$result" = "$val1 $val2" ]; then
 else
 	jtest_result fail
 fi
+
+################################################################################
+# The container's user directory has been created with the right home
+# directory.
+################################################################################
+jtest_prepare "the user's home in passwd == \$HOME"
+passwd_home=$($cqfd run "grep ^$(whoami): /etc/passwd |cut -d: -f6")
+user_home=$($cqfd run "echo \$HOME")
+
+if [ "$passwd_home" = "$user_home" ]; then
+	jtest_result pass
+else
+	jtest_result fail
+fi


### PR DESCRIPTION
Instead of printing a warning, terminate with an error in case the user
still uses a legacy environment variable. After testing in the real
world, we noticed many users didn't notice the warnings.