### PR TITLE
Use sudo instead su in the launcher script

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -271,7 +271,12 @@ chown $UID:$GROUPS $cqfd_user_home
 
 # run the provided command in the working directory
 cd $cqfd_user_cwd
-su $cqfd_user -p -c "\$@"
+if [ -x "$(which sudo)" ]; then
+  # Use sudo to provide a controlling TTY for the executed command
+  sudo -u $cqfd_user sh -c "\$@"
+else
+  su $cqfd_user -p -c "\$@"
+fi
 EOF
 	echo $tmpfile
 }


### PR DESCRIPTION
sudo will provide a controlling TTY, su does not
Therefore use sudo when it is available in the container

This is a possible solution for #62 