### PR TITLE
cqfd: fix character escape with bash 5.0

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -71,8 +71,8 @@ parse_ini_config_file() {
 	if ! ini="$(<$1)"; then           # read the file
 		die "$1: No such file!"
 	fi
-	ini="${ini//[/\[}"          # escape [
-	ini="${ini//]/\]}"          # escape ]
+	ini="${ini//[/\\[}"          # escape [
+	ini="${ini//]/\\]}"          # escape ]
 	IFS=$'\n' && ini=( ${ini} ) # convert to line-array
 	ini=( ${ini[*]//;*/} )      # remove comments with ;
 	ini=( ${ini[*]/\    =/=} )  # remove tabs before =


### PR DESCRIPTION
The ini config file is not escaping correctly the '[' and ']' characters
with bash 5.0. Add double backslash to escape those characters.
This fix is working for Bash versions 4.4.x and 5.0.