### PR TITLE
cqfd: add support to follow symlink files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # ChangeLog for cqfd
 
+* Add `tar_options` cqfd option to add extra options to tar command.
+
 ## Version 5.1.0 (2019-05-13)
 
 * The launcher script in the container now gives extra infos in

--- a/README.md
+++ b/README.md
@@ -126,6 +126,12 @@ specified for the archive to be stored at the root of the archive,
 which is desired in some scenarios. This feature is not supported with
 .zip archives.
 
+For tar archives, setting ``tar_options`` will add extra options to the
+tar command.
+For example, setting ``tar_options=-h`` will copy all symlink files as
+hardlinks, which is desired in some scenarios. This feature is not
+supported with .zip archives.
+
 ``distro``: the name of the directory containing the Dockerfile. By
 default, cqfd uses ``"docker"``, and ``.cqfd/docker/Dockerfile` is
 used.

--- a/cqfd
+++ b/cqfd
@@ -236,6 +236,12 @@ make_archive() {
 		local tar_opts='--transform s/.*\///g'
 	fi
 
+	# setting tar_options will add the following options to the tar
+	# command
+	if [ -n "$tar_options" ]; then
+		local tar_opts="$tar_opts $tar_options"
+	fi
+
 	# support the following archive formats
 	case "$release_archive" in
 	*.tar.xz)
@@ -335,6 +341,7 @@ config_load() {
 	release_files="`eval echo $files`"
 	release_archive="$archive"
 	release_transform="$tar_transform"
+	tar_options="$tar_options"
 
 	# This will look like fooinc_reponame
 	if [ -n "$project_org" -a -n "$project_name" ]; then

--- a/tests/06-cqfd_release
+++ b/tests/06-cqfd_release
@@ -80,6 +80,40 @@ sed -i -e '$ s!^tar_transform.*$!!' .cqfdrc
 rm -f cqfd-test.tar.xz
 
 ################################################################################
+# cqfd follows the symlinks of the files, only if tar_options=-h,
+# only for tar archive.
+################################################################################
+
+jtest_prepare "symlink files are copied in the tar archive"
+cqfd run ln -s a/cqfd_a.txt link.txt
+rel_files_link="a/cqfd_a.txt link.txt"
+sed -i '/files=/d' .cqfdrc
+echo "files=\"$rel_files_link\"" >>.cqfdrc
+echo "tar_options=-h" >>.cqfdrc
+
+$cqfd release
+result="pass"
+tmp_dir=$(mktemp -d)
+if ! tar xf cqfd-test.tar.xz -C "${tmp_dir}"; then
+	result="fail"
+fi
+
+if [ -L "${tmp_dir}"/link.txt ] || ! diff "${tmp_dir}"/a/cqfd_a.txt "${tmp_dir}"/link.txt; then
+	result="fail"
+fi
+
+jtest_result $result
+
+# revert the changes in .cqfdrc file
+cqfd run rm link.txt
+sed -i '/tar_options/d' .cqfdrc
+sed -i '/files=/d' .cqfdrc
+echo "files=\"$rel_files\"" >>.cqfdrc
+
+rm -f cqfd-test.tar.xz
+rm -rf "${tmp_dir}"
+
+################################################################################
 # Now test adding an archive filename template to the config
 ################################################################################
 jtest_prepare "build.archive can template filenames"


### PR DESCRIPTION
For tar archives, setting tar_follow_symlink to yes will copy and
derefence the file the symlink is pointing to.

This option is desired in some scenarios when the released files are
symlinks to timestamped files.

Add unitary tests.