### PR TITLE
cqfd: add CQFD_EXTRA_BUILD_ARGS option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # ChangeLog for cqfd
 
 * Add `tar_options` cqfd option to add extra options to tar command.
+* Add CQFD_EXTRA_BUILD_ARGS to pass args and options to the image build process.
 
 ## Version 5.1.0 (2019-05-13)
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,11 @@ docker-run options to be append to the starting container.
 Format is the same as (and passed to) docker-run’s options.
 See 'docker run --help'.
 
+``CQFD_EXTRA_BUILD_ARGS``: A space-separated list of additional
+docker-build options to be append to the building image.
+Format is the same as (and passed to) docker-build’s options.
+See 'docker build --help'.
+
 ### Other command-line options ###
 
 In some conditions you may want to use an alternate config file with

--- a/cqfd
+++ b/cqfd
@@ -109,9 +109,9 @@ docker_build() {
 		die "no Dockerfile found at location $dockerfile"
 	fi
 	if [ -z "$project_build_context" ]; then
-		docker build ${quiet:+-q} -t "$docker_img_name" "$(dirname "$dockerfile")"
+		docker build ${quiet:+-q} $CQFD_EXTRA_BUILD_ARGS -t "$docker_img_name" "$(dirname "$dockerfile")"
 	else
-		docker build ${quiet:+-q} -t "$docker_img_name" "${project_build_context}" -f "$dockerfile"
+		docker build ${quiet:+-q} $CQFD_EXTRA_BUILD_ARGS -t "$docker_img_name" "${project_build_context}" -f "$dockerfile"
 	fi
 }
 

--- a/tests/05-cqfd_init_extra_env
+++ b/tests/05-cqfd_init_extra_env
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# validate the behavior of CQFD_EXTRA_BUILD_ARGS
+
+. $(dirname "$0")/jtest.inc "$1"
+cqfd="$TDIR/.cqfd/cqfd"
+
+cd $TDIR/
+
+################################################################################
+# Create a special test context
+################################################################################
+cp -f .cqfd/docker/Dockerfile .cqfd/docker/Dockerfile.orig
+cp -f .cqfd/docker/Dockerfile.init_extra_env .cqfd/docker/Dockerfile
+
+################################################################################
+# 'cqfd init' without CQFD_EXTRA_BUILD_ARGS should fail
+################################################################################
+jtest_prepare "cqfd init without using CQFD_EXTRA_BUILD_ARGS"
+if $cqfd init; then
+	jtest_result fail
+else
+	jtest_result pass
+fi
+
+################################################################################
+# 'cqfd init' with CQFD_EXTRA_BUILD_ARGS should lead
+################################################################################
+jtest_prepare "cqfd init using CQFD_EXTRA_BUILD_ARGS"
+export CQFD_EXTRA_BUILD_ARGS="--build-arg FOO=foo --no-cache"
+if $cqfd init; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
+################################################################################
+# restore initial .cqfdrc and Dockerfile
+################################################################################
+mv -f .cqfd/docker/Dockerfile.orig .cqfd/docker/Dockerfile

--- a/tests/test_data/.cqfd/docker/Dockerfile.init_extra_env
+++ b/tests/test_data/.cqfd/docker/Dockerfile.init_extra_env
@@ -1,0 +1,8 @@
+FROM ubuntu:14.04
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends make
+
+ARG FOO
+RUN touch ${FOO}


### PR DESCRIPTION
To provide flexibility during day-to-day development tasks, the user may
set CQFD_EXTRA_BUILD_ARGS to add extra options to cqfd docker build
command.

It could be useful to rebuild without docker cache or setting http_proxy variables.