### PR TITLE
cqfd: add the username in the docker image name

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -347,7 +347,7 @@ config_load() {
 
 	# This will look like fooinc_reponame
 	if [ -n "$project_org" -a -n "$project_name" ]; then
-		docker_img_name="cqfd_${project_org}_${project_name}"
+		docker_img_name="cqfd${USER:+_${USER}}_${project_org}_${project_name}"
 	else
 		die "project.org and project.name not configured"
 	fi


### PR DESCRIPTION
When using cqfd on a shared machine, all users have access to docker
images (including cqfd images). To avoid conflicts between several
users using and updating the same cqfd Dockerfile, the name of the
docker's image must include the username if available.

Signed-off-by: Jean-Marie LEMETAYER <jean-marie.lemetayer@savoirfairelinux.com>