### PR TITLE
Add support for alternative and external cqfd files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # ChangeLog for cqfd
 
+* Add the `-d` option to specify an alternate cqfd directory.
+* Add the `-C` option to change the working directory.
 * Containers are now named `cqfd_%user_%company_%project` instead of
   `cqfd_%company_%project`. This prevents collisions with Docker when
   several users are using it on the same machine.

--- a/README.md
+++ b/README.md
@@ -189,10 +189,28 @@ See 'docker build --help'.
 
 ### Other command-line options ###
 
-In some conditions you may want to use an alternate config file with
-cqfd. This is what the -f option is for:
+In some conditions you may want to use alternate cqfd filenames and / or an
+external working directory. These options can be used to control the cqfd
+configuration files:
 
-    $ cqfd -f .cqfdrc.test
+The working directory can be changed using the `-C` option:
+
+    $ cqfd -C external/directory
+
+An alternate cqfd directory can be specified with the `-d` option:
+
+    $ cqfd -d cqfd_alt
+
+An alternate cqfdrc file can be specified with the `-f` option:
+
+    $ cqfd -f cqfdrc_alt
+
+These options can be combined together:
+
+    $ cqfd -C external/directory -d cqfd_alt -f cqfdrc_alt
+    $ # cqfd will use:
+    $ #  - cqfd directory: external/directory/cqfd_alt
+    $ #  - cqfdrc file: external/directory/cqfdrc_alt
 
 ## Build Container Environment ##
 

--- a/bash-completion
+++ b/bash-completion
@@ -20,7 +20,7 @@ _cqfd() {
 	_init_completion || return
 
 	case $prev in
-	-f)
+	-C|-d|-f)
 		_filedir
 		return
 		;;
@@ -50,7 +50,7 @@ _cqfd() {
 		;;
 	esac
 
-	local opts="-f -b -q -V --version -h --help"
+	local opts="-C -d -f -b -q -V --version -h --help"
 	if [[ "$cur" == -* ]]; then
 		COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
 		return

--- a/cqfd
+++ b/cqfd
@@ -21,7 +21,7 @@ set -e
 
 PROGNAME=`basename $0`
 VERSION=5.1.0
-dockerfile=".cqfd/docker/Dockerfile"
+cqfddir=".cqfd"
 cqfdrc=".cqfdrc"
 cqfd_user='builder'
 cqfd_user_home='/home/builder'
@@ -34,6 +34,8 @@ Usage: $PROGNAME [OPTION ARGUMENT] [COMMAND] [ARGUMENTS]
 
 Options:
     -f <file>           Use file as config file (default .cqfdrc).
+    -d <directory>      Use directory as cqfd directory (default .cqfd).
+    -C <directory>      Use the specified working directory.
     -b <flavor_name>    Target a specific build flavor.
     -q                  Turn on quiet mode
     -v or --version     Show version.
@@ -105,6 +107,8 @@ die() {
 
 # docker_build() - Initialize build container
 docker_build() {
+	local dockerfile="${cqfddir}/${distro:-docker}/Dockerfile"
+
 	if [ ! -f $dockerfile ]; then
 		die "no Dockerfile found at location $dockerfile"
 	fi
@@ -384,7 +388,6 @@ config_load() {
 
 	# Adapt things for a specific container
 	if [ -n "$distro" ]; then
-		dockerfile=".cqfd/$distro/Dockerfile"
 		docker_img_name+="_$distro"
 	fi
 }
@@ -414,9 +417,17 @@ while [ $# -gt 0 ]; do
 		shift
 		flavor="$1"
 		;;
+	-d)
+		shift
+		cqfddir="$1"
+		;;
 	-f)
 		shift
 		cqfdrc="$1"
+		;;
+	-C)
+		shift
+		cd "$1"
 		;;
 	-q)
 		quiet=true

--- a/tests/05-cqfd_init_alt_ext
+++ b/tests/05-cqfd_init_alt_ext
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+. `dirname $0`/jtest.inc "$1"
+cd $TDIR/
+
+################################################################################
+# First, move every local cqfd files into an external directory and use
+# alternate filenames
+################################################################################
+extdir="external/dir"
+mkdir -p ${extdir}
+mv .cqfd ${extdir}/cqfd
+mv .cqfdrc ${extdir}/cqfdrc
+cqfd="$TDIR/${extdir}/cqfd/cqfd"
+
+################################################################################
+# 'cqfd init' without local files should fail
+################################################################################
+jtest_prepare "cqfd init without local files should fail"
+if $cqfd init; then
+	jtest_result fail
+else
+	jtest_result pass
+fi
+
+################################################################################
+# 'cqfd init' using alternate filenames in an external directory should work
+################################################################################
+jtest_prepare "cqfd init using alternate filenames in an external directory should work"
+if $cqfd -C ${extdir} -d cqfd -f cqfdrc init; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
+################################################################################
+# restore local cqfd files
+################################################################################
+mv ${extdir}/cqfdrc .cqfdrc
+mv ${extdir}/cqfd .cqfd
+rmdir -p ${extdir}


### PR DESCRIPTION
The -f option allow to use external configuration file but there was no
way to use external docker directories.