### PR TITLE
Use generic date format for rfc3339

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -233,7 +233,7 @@ make_archive() {
 	# template the generated archive's filename
 	local git_short=`git rev-parse --short HEAD 2>/dev/null`
 	local git_long=`git rev-parse HEAD 2>/dev/null`
-	local date_rfc3339=`date --rfc-3339='date'`
+	local date_rfc3339=`date +"%Y-%m-%d"`
 
 	# default name for the archive if not set
 	if [ -z "$release_archive" ]; then


### PR DESCRIPTION
proposed update for date format in cqfd:
- make cqfd work with date on macosx
- keep linux compatibility