### PR TITLE
cqfd: always remove the launcher

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -196,6 +196,8 @@ docker_run() {
 
 	tmp_launcher=$(make_launcher)
 
+	trap "rm -f $tmp_launcher" EXIT
+
 	docker run --privileged \
 	       $CQFD_EXTRA_RUN_ARGS \
 	       --rm \
@@ -208,8 +210,6 @@ docker_run() {
 	       ${SSH_AUTH_SOCK:+ -v $SSH_AUTH_SOCK:$cqfd_user_home/.sockets/ssh} \
 	       ${SSH_AUTH_SOCK:+ -e SSH_AUTH_SOCK=$cqfd_user_home/.sockets/ssh} \
 	       $docker_img_name cqfd_launch "$@" 2>&1
-
-	rm -f $tmp_launcher
 }
 
 # make_archive(): Create a release package.


### PR DESCRIPTION
As the script is using the "set -e" option, if the "docker run" command
fails the temporary launcher file "$tmp_launcher" is never removed.

Using the "trap ... EXIT" command allow to always remove the temporary
launcher even if previous commands have failed.