### PR TITLE
WIP: Improvements

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -25,41 +25,45 @@ cqfd_user='builder'
 cqfd_user_home='/home/builder'
 cqfd_user_cwd="$cqfd_user_home/src"
 
-print_usage() {
+print_help() {
 	cat <<- EOF
-	usage: ${0##*/} [options] [<command> [<args>...]]
+	Usage: ${0##*/} [options] [<command> [<args>...]]
 
 	${0##*/} provides a quick and convenient way to run commands in the current
-	directory, but within a Docker container defined in a per-project rcfile.
+	directory, but within a Docker container defined in a per-project config file.
 
 	Available commands are:
 	    init                    Initialize the project container.
 	    run [<args>...]         Run the specified arguments inside the project
 	                            container. If no arguments are present those defined
-	                            in the rcfile are used.
+	                            in the config file are used.
 	    release [<args>...]     Execute the run command and release the software.
-	    flavors                 List the available build flavors from the rcfile.
+	    flavors                 List the available flavors from the config file.
 
 	The run command is assumed when none is given in the command line.
 
 	Options:
-	    -f <rcfile>             Use the specified rcfile [default: .cqfdrc].
-	    -d <cqfd_directory>     Use the specified cqfd directory [default: .cqfd].
-	    -C <working_directory>  Use the specified working directory.
-	    -b <build_flavor>       Use the specified build flavor.
-	    -q                      Turn on quiet mode.
+	    -f <file>, --config-file <file>
+	                            Use the specified config file [default: .cqfdrc].
+	    -d <path>, --cqfd-dir <path>
+	                            Use the specified cqfd directory [default: .cqfd].
+	    -C <path>, --working-dir <path>
+	                            Use the specified working directory.
+	    -b <flavor>, --flavor <flavor>
+	                            Use the specified flavor.
+	    -q, --quiet             Turn on quiet mode.
 	    --version               Show version.
 	    --help                  Show this help.
 
 	Files:
-	   .cqfdrc                  The default rcfile.
-	                            This file can be replaced using the -f option.
+	   .cqfdrc                  The default config file.
+	                            This file can be replaced using the --config-file option.
 	   .cqfd/                   The default cqfd directory.
-	                            This directory can be replaced using the -d option.
+	                            This directory can be replaced using the --cqfd-dir option.
 
 	Environment:
-	   CQFD_EXTRA_BUILD_ARGS    Extra arguments to give to the 'docker build'.
-	   CQFD_EXTRA_RUN_ARGS      Extra arguments to give to the 'docker run'.
+	   CQFD_EXTRA_BUILD_ARGS    Extra arguments to give to the docker build.
+	   CQFD_EXTRA_RUN_ARGS      Extra arguments to give to the docker run.
 	EOF
 }
 
@@ -406,78 +410,115 @@ config_load() {
 	fi
 }
 
-has_to_release=false
-while [ $# -gt 0 ]; do
-	case "$1" in
-	help|-h|"--help")
-		print_usage
-		exit 0
-		;;
-	version|-v|"--version")
-		print_version
-		exit 0
-		;;
-	init)
-		config_load $flavor
-		docker_build
-		exit $?
-		;;
-	flavors)
-		config_load
-		echo $flavors
-		exit 0
-		;;
-	-b)
-		shift
-		flavor="$1"
-		;;
-	-d)
-		shift
-		cqfddir="$1"
-		;;
-	-f)
-		shift
-		cqfdrc="$1"
-		;;
-	-C)
-		shift
-		cd "$1"
-		;;
-	-q)
-		quiet=true
-		;;
-	run|release)
-		if [ "$1" = "release" ]; then
-			has_to_release=true
-		fi
-		if [ $# -gt 1 ]; then
-			shift
-			build_cmd_alt="$@"
-		fi
-		break
-		;;
-	?*)
-		echo "Unknown command: $1"
-		print_usage
-		exit 1
-		;;
-	*)
-		# empty or no argument case
-		;;
+while getopts ":f:d:C:b:q-:" OPTCHAR
+do
+	case "${OPTCHAR}" in
+		-)
+			case "${OPTARG}" in
+				config-file)
+					cqfdrc="${!OPTIND}"
+					OPTIND=$((${OPTIND} + 1))
+					;;
+				cqfd-dir)
+					cqfddir="${!OPTIND}"
+					OPTIND=$((${OPTIND} + 1))
+					;;
+				working-dir)
+					cd "${!OPTIND}"
+					OPTIND=$((${OPTIND} + 1))
+					;;
+				flavor)
+					flavor="${!OPTIND}"
+					OPTIND=$((${OPTIND} + 1))
+					;;
+				quiet)
+					quiet=true
+					;;
+				version)
+					print_version
+					exit 0
+					;;
+				help)
+					print_help
+					exit 0
+					;;
+				*)
+					print_help
+					exit 1
+					;;
+			esac
+			;;
+		f)
+			cqfdrc="${OPTARG}"
+			;;
+		d)
+			cqfddir="${OPTARG}"
+			;;
+		C)
+			cd "${OPTARG}"
+			;;
+		b)
+			flavor="${OPTARG}"
+			;;
+		q)
+			quiet=true
+			;;
+		*)
+			print_help
+			exit 1
+			;;
 	esac
-	shift
 done
 
-config_load $flavor
+shift $((${OPTIND} - 1))
 
-if [ -n "$build_cmd_alt" ]; then
-	build_cmd=$build_cmd_alt
-elif [ -z "$build_cmd" ]; then
-	die "No build.command defined in $cqfdrc !"
-fi
+do_init() {
+	config_load ${flavor}
+	docker_build
+}
 
-docker_run "$build_cmd"
+do_run() {
+	config_load ${flavor}
 
-if $has_to_release; then
+	if [ ${#} -gt 0 ]
+	then
+		build_cmd="${@}"
+
+	elif [ -z "${build_cmd}" ]
+	then
+		die "No build.command defined in ${cqfdrc} !"
+	fi
+
+	docker_run "${build_cmd}"
+}
+
+do_release() {
+	do_run ${@}
 	make_archive
-fi
+}
+
+do_flavors() {
+	config_load
+	echo "${flavors}"
+}
+
+case "${1:-run}" in
+	init)
+		do_init
+		;;
+	run)
+		shift || true
+		do_run ${@}
+		;;
+	release)
+		shift || true
+		do_release ${@}
+		;;
+	flavors)
+		do_flavors
+		;;
+	*)
+		print_help
+		exit 1
+		;;
+esac

--- a/cqfd
+++ b/cqfd
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 #
 # cqfd - run commands in a Dockerized environment
 #
@@ -16,8 +16,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
-set -e
 
 VERSION=5.1.0
 

--- a/cqfd
+++ b/cqfd
@@ -1,8 +1,8 @@
 #!/bin/bash
 #
-# cqfd - a tool to wrap commands in controlled Docker containers
+# cqfd - run commands in a Dockerized environment
 #
-# Copyright (C) 2015-2018 Savoir-faire Linux, Inc.
+# Copyright (C) 2015-2020 Savoir-faire Linux, Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,48 +15,64 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 set -e
 
-PROGNAME=`basename $0`
 VERSION=5.1.0
+
 cqfddir=".cqfd"
 cqfdrc=".cqfdrc"
 cqfd_user='builder'
 cqfd_user_home='/home/builder'
 cqfd_user_cwd="$cqfd_user_home/src"
 
-## usage() - print usage on stdout
-usage() {
-	cat <<EOF
-Usage: $PROGNAME [OPTION ARGUMENT] [COMMAND] [ARGUMENTS]
+print_usage() {
+	cat <<- EOF
+	usage: ${0##*/} [options] [<command> [<args>...]]
 
-Options:
-    -f <file>           Use file as config file (default .cqfdrc).
-    -d <directory>      Use directory as cqfd directory (default .cqfd).
-    -C <directory>      Use the specified working directory.
-    -b <flavor_name>    Target a specific build flavor.
-    -q                  Turn on quiet mode
-    -v or --version     Show version.
-    -h or --help        Show this help text.
+	${0##*/} provides a quick and convenient way to run commands in the current
+	directory, but within a Docker container defined in a per-project rcfile.
 
-Commands:
-    init     Initialize project build container
-    flavors  List flavors from config file to stdout
-    run      Run argument(s) inside build container
-    release  Run argument(s) and release software
-    help     Show this help text
+	Available commands are:
+	    init                    Initialize the project container.
+	    run [<args>...]         Run the specified arguments inside the project
+	                            container. If no arguments are present those defined
+	                            in the rcfile are used.
+	    release [<args>...]     Execute the run command and release the software.
+	    flavors                 List the available build flavors from the rcfile.
 
-    By default, run is assumed, and the run command is the one
-    configured in .cqfdrc.
+	The run command is assumed when none is given in the command line.
 
-    cqfd is Copyright (C) 2015-2018 Savoir-faire Linux, Inc.
+	Options:
+	    -f <rcfile>             Use the specified rcfile [default: .cqfdrc].
+	    -d <cqfd_directory>     Use the specified cqfd directory [default: .cqfd].
+	    -C <working_directory>  Use the specified working directory.
+	    -b <build_flavor>       Use the specified build flavor.
+	    -q                      Turn on quiet mode.
+	    --version               Show version.
+	    --help                  Show this help.
 
-    This program comes with ABSOLUTELY NO WARRANTY. This is free
-    software, and you are welcome to redistribute it under the terms
-    of the GNU GPLv3 license; see the LICENSE for more informations.
-EOF
+	Files:
+	   .cqfdrc                  The default rcfile.
+	                            This file can be replaced using the -f option.
+	   .cqfd/                   The default cqfd directory.
+	                            This directory can be replaced using the -d option.
+
+	Environment:
+	   CQFD_EXTRA_BUILD_ARGS    Extra arguments to give to the 'docker build'.
+	   CQFD_EXTRA_RUN_ARGS      Extra arguments to give to the 'docker run'.
+	EOF
+}
+
+print_version() {
+	cat <<- EOF
+	${0##/*} ${VERSION}
+
+	Copyright (C) 2015-2020 Savoir-faire Linux, Inc.
+	This program comes with ABSOLUTELY NO WARRANTY. This is free software,
+	and you are welcome to redistribute it under the terms of the GNU GPLv3 license.
+	EOF
 }
 
 # parse_ini_config_file()
@@ -396,11 +412,11 @@ has_to_release=false
 while [ $# -gt 0 ]; do
 	case "$1" in
 	help|-h|"--help")
-		usage
+		print_usage
 		exit 0
 		;;
 	version|-v|"--version")
-		echo $VERSION
+		print_version
 		exit 0
 		;;
 	init)
@@ -444,7 +460,7 @@ while [ $# -gt 0 ]; do
 		;;
 	?*)
 		echo "Unknown command: $1"
-		usage
+		print_usage
 		exit 1
 		;;
 	*)


### PR DESCRIPTION
Hi @joufella 
Are you open to some improvements like this ?

For now, here is the improvement list:

- Update the option parsing to use the bash builtin getopts
- Add long options support
- Update the help and version text to follow [docopt](http://docopt.org) recommandations and to be able to use [help2man](https://www.gnu.org/software/help2man/) to generate a manual page. Here is the line I use for testing:
```
help2man --no-info --name "run commands in a Dockerized environment" ./cqfd | man -l -
```

I have other ideas like:

- Be able to add CQFD_EXTRA_{BUILD,RUN}_ARGS default value in the config file
- Rename the `[build]` section to `[run]` in the config file as it is more relevant
- Rename the `.cqfd/docker` in `.cqfd/default` as it is more relevant
- Add the manual pages for `cqfd` and `cqfd_conf` during the installation
- Create a debian package and [host it on github pages](https://pmateusz.github.io/linux/2017/06/30/linux-secure-apt-repository.html)
- Fix highlighting issue with the ini parser script

I would like to have your feedback about these ideas.