### PR TITLE
add 'docker run' pre command

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -198,18 +198,18 @@ docker_run() {
 
 	trap "rm -f $tmp_launcher" EXIT
 
-	docker run --privileged \
+	${CQFD_DOCKER_PRE_RUN:=$SHELL -c} "docker run --privileged \
 	       $CQFD_EXTRA_RUN_ARGS \
 	       --rm \
 	       --log-driver=none \
 	       -v $tmp_launcher:/bin/cqfd_launch \
 	       -v ~/.ssh:$cqfd_user_home/.ssh \
-	       -v "$PWD":$cqfd_user_cwd \
+	       -v \"$PWD\":$cqfd_user_cwd \
 	       $home_env_var \
 	       $interactive_options \
 	       ${SSH_AUTH_SOCK:+ -v $SSH_AUTH_SOCK:$cqfd_user_home/.sockets/ssh} \
 	       ${SSH_AUTH_SOCK:+ -e SSH_AUTH_SOCK=$cqfd_user_home/.sockets/ssh} \
-	       $docker_img_name cqfd_launch "$@" 2>&1
+	       $docker_img_name cqfd_launch \"$@\" 2>&1"
 }
 
 # make_archive(): Create a release package.


### PR DESCRIPTION
It could be useful to launch some custom commands just before the
'docker run' one to prepare a specific environment.
An example is to create a pool of cqfd running instances using 'sem'
command with:
'export CQFD_DOCKER_PRE_RUN="sem -j2 --fg --tty --id cqfd.sem"'
This will create a pool of 2 (-j2) running cqfd instances and will
make the 3rd instance waiting a previous one to end.
This kind of setup is often useful on build servers to allocate build
tokens.
If CQFD_DOCKER_PRE_RUN is not set, 'docker run' will be launched
normally by setting CQFD_DOCKER_PRE_RUN to your current shell
interpreter '$SHELL -c'.

Signed-off-by: Gilles DOFFE <gilles.doffe@savoirfairelinux.com>