### PR TITLE
cqfd: add the run -c argument

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -30,7 +30,7 @@ cqfd_user_cwd="$cqfd_user_home/src"
 ## usage() - print usage on stdout
 usage() {
 	cat <<EOF
-Usage: $PROGNAME [OPTION ARGUMENT] [COMMAND] [ARGUMENTS]
+Usage: $PROGNAME [OPTION ARGUMENT] [COMMAND] [COMMAND OPTION] [ARGUMENTS]
 
 Options:
     -f <file>           Use file as config file (default .cqfdrc).
@@ -50,6 +50,10 @@ Commands:
 
     By default, run is assumed, and the run command is the one
     configured in .cqfdrc.
+
+Command options:
+    -c      Only with run or release commands. Concatenate arguments
+            with the command configured in .cqfdrc.
 
     cqfd is Copyright (C) 2015-2022 Savoir-faire Linux, Inc.
 
@@ -440,7 +444,12 @@ while [ $# -gt 0 ]; do
 		fi
 		if [ $# -gt 1 ]; then
 			shift
-			build_cmd_alt="$@"
+            if [ "$1" = "-c" ] ; then
+                shift
+                build_cmd_c="$@"
+            else
+    			build_cmd_alt="$@"
+            fi
 		fi
 		break
 		;;
@@ -460,6 +469,8 @@ config_load $flavor
 
 if [ -n "$build_cmd_alt" ]; then
 	build_cmd=$build_cmd_alt
+elif [ -n "$build_cmd_c" ]; then
+	build_cmd="$build_cmd $build_cmd_c"
 elif [ -z "$build_cmd" ]; then
 	die "No build.command defined in $cqfdrc !"
 fi

--- a/tests/05-cqfd_run_c
+++ b/tests/05-cqfd_run_c
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+. `dirname $0`/jtest.inc "$1"
+cqfd="$TDIR/.cqfd/cqfd"
+test_file="a/cqfd_a.txt"
+test_run_c_file="test_run_c.txt"
+
+cd $TDIR/
+
+# First pass: build the default command with run -c
+# Second pass: concatenate default command build with an additional option
+
+for i in 0 1; do
+
+	if [ -f "$test_file" ] || [ -f "$test_run_c_file" ]; then
+		jtest_log fatal "$test_file or $test_run_c_file already present before test"
+		rm -f $test_file
+		rm -f $test_run_c_file
+		continue
+	fi
+
+	if [ "$i" = "1" ]; then
+		jtest_prepare "running \"cqfd run -c\" makes it run with concatene arguments"
+		$cqfd run -c --debug >> $test_run_c_file
+
+		# at the end of this test, $test_run_c_file is populated
+		if ! grep -qw "target \`build'" $test_run_c_file; then
+			jtest_log fatal "$test_run_c_file not present after test"
+			jtest_result fail
+			rm -f $test_run_c_file
+			continue
+		fi
+	else
+		jtest_prepare "running \"cqfd run -c\" with no argument makes it run"
+		$cqfd run -c
+	fi
+
+	# at the end of either test, $test_file is populated
+	if ! grep -qw "cqfd" $test_file; then
+		jtest_log fatal "$test_file not present after test"
+		jtest_result fail
+		rm -f $test_file
+		continue
+	else
+		jtest_result pass
+	fi
+
+	rm -f $test_file
+	rm -f $test_run_c_file
+done

--- a/tests/05-cqfd_run_c_flavor
+++ b/tests/05-cqfd_run_c_flavor
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+. `dirname $0`/jtest.inc "$1"
+cqfd="$TDIR/.cqfd/cqfd"
+flavor="foo"
+test_file=$flavor
+test_run_c_file="test_run_c.txt"
+
+cd $TDIR/
+
+# First pass: build a simple flavor with run -c
+# Second pass: concatenate flavor build with an additional option
+
+for i in 0 1; do
+	jtest_log info "run cqfd run -c with a given '$flavor' flavor, pass $i"
+
+	if [ -f "$test_file" ] || [ -f "$test_run_c_file" ]; then
+		jtest_log fatal "$test_file or $test_run_c_file already present before test"
+		rm -f $test_file
+		rm -f $test_run_c_file
+		continue
+	fi
+
+	if [ "$i" = "0" ]; then
+		jtest_prepare "cqfd run -c build cmd for '$flavor' flavor"
+		$cqfd -b $flavor run -c
+	else
+		jtest_prepare "build cmd for '$flavor' flavor and concatenate with an additional option"
+		$cqfd -b $flavor run -c --debug >> $test_run_c_file
+
+		# at the end of this test, $test_run_c_file is populated
+		if ! grep -qw "target \`foo'" $test_run_c_file; then
+			jtest_log fatal "$test_run_c_file not present after test"
+			jtest_result fail
+			rm -f $test_run_c_file
+			continue
+		fi
+	fi
+
+	# at the end of either test, $test_file is populated
+	if ! grep -qw "cqfd" $test_file; then
+		jtest_log fatal "$test_file not present after test"
+		jtest_result fail
+		rm -f $test_file
+		continue
+	else
+		jtest_result pass
+	fi
+
+	rm -f $test_file
+	rm -f $test_run_c_file
+done


### PR DESCRIPTION
Except for the default flavor command, do not override the command
defined in flavor by the one given with the run argument. Instead
concatenate the two command.