### PR TITLE
Handle special characters in usernames

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -387,7 +387,8 @@ config_load() {
 
 	# This will look like fooinc_reponame
 	if [ -n "$project_org" -a -n "$project_name" ]; then
-		docker_img_name="cqfd${USER:+_${USER}}_${project_org}_${project_name}"
+		format_user=`echo $USER | sed 's/[^0-9a-zA-Z\-]/_/g'`
+		docker_img_name="cqfd${format_user:+_${format_user}}_${project_org}_${project_name}"
 	else
 		die "project.org and project.name not configured"
 	fi


### PR DESCRIPTION
Despite Linux warnings, some people may have username containing '@' or '$' characters. Such characters are incompatible with the docker tag system and causes bugs later in cqfd.
To avoid future headaches, this commit formats the docker tag to use only letters, digits, underscores and dashes.

Note: cqfd launches a useradd command at the start of the docker container. On some distributions, this command will fail if the username contains such characters. This commits doesn't handle this problem.