### PR TITLE
Use dockerfile hash to tag docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ Examples are available in the samples/ directory.
 cqfd will use the provided Dockerfile to create a normalized runtime
 build environment for your project.
 
+Warning : `cqfd init` creates and names a new docker image every time
+the Dockerfile is modified. This could result in a huge amount of unused
+images that cannot be purge automatically. cqfd doesn't implement any
+systematic clean system for now.
+
 ## Using cqfd on a daily basis ##
 
 ### Regular builds ###

--- a/cqfd
+++ b/cqfd
@@ -110,8 +110,6 @@ die() {
 
 # docker_build() - Initialize build container
 docker_build() {
-	local dockerfile="${cqfddir}/${distro:-docker}/Dockerfile"
-
 	if [ ! -f $dockerfile ]; then
 		die "no Dockerfile found at location $dockerfile"
 	fi
@@ -138,8 +136,12 @@ docker_build() {
 # arg$1: the command string to execute as $cqfd_user
 #
 docker_run() {
-	local interactive_options
 
+	if ! docker image inspect $docker_img_name &> /dev/null; then
+		die "The docker image doesn't exist, launch 'cqfd init' to create it"
+	fi
+
+	local interactive_options
 	if tty -s; then
 		interactive_options="-ti"
 	fi
@@ -385,10 +387,13 @@ config_load() {
 	release_transform="$tar_transform"
 	tar_options="$tar_options"
 
+	dockerfile="${cqfddir}/${distro:-docker}/Dockerfile"
+
 	# This will look like fooinc_reponame
 	if [ -n "$project_org" -a -n "$project_name" ]; then
 		local format_user=`echo $USER | sed 's/[^0-9a-zA-Z\-]/_/g'`
-		docker_img_name="cqfd${format_user:+_${format_user}}_${project_org}_${project_name}"
+		local dockerfile_hash=`sha256sum $dockerfile | cut -b 1-7`
+		docker_img_name="cqfd${format_user:+_${format_user}}_${project_org}_${project_name}_${dockerfile_hash}"
 	else
 		die "project.org and project.name not configured"
 	fi

--- a/tests/05-cqfd_run
+++ b/tests/05-cqfd_run
@@ -36,3 +36,17 @@ for i in 0 1; do
 
 	rm -f $test_file
 done
+
+################################################################################
+# If the Dockerfile changed and no init is done again, 'cqfd run' should fail
+################################################################################
+jtest_prepare "Modifying the Dockerfile should require running 'cqfd init' again"
+dockerfile=.cqfd/docker/Dockerfile
+echo "RUN echo $RANDOM" >> $dockerfile
+if $TDIR/.cqfd/cqfd run; then
+  jtest_result fail
+else
+  jtest_result pass
+fi
+# restore Dockerfile
+sed -i '$d' $dockerfile


### PR DESCRIPTION
cqfd init and cqfd run have to be synchronise to ensure using the correct image.
This can be done by putting the short hash of the Dockerfile in the image name when creating the image