### PR TITLE
auto locate project directory from sub-dirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Version 5.4.0-dev (Coming soon)
 
-* Add the `-c` option to cqfd run/release, to pass extra arguments
+* Add the `-c` option to cqfd run/release, to pass extra arguments.
+* When in a project sub-directory, try to locate the cqfd context in parent
+  directories automatically.
 
 ## Version 5.3.0 (2022-01-05)
 

--- a/cqfd
+++ b/cqfd
@@ -210,7 +210,7 @@ docker_run() {
 	       --log-driver=none \
 	       -v "$tmp_launcher":/bin/cqfd_launch \
 	       -v ~/.ssh:"$cqfd_user_home"/.ssh \
-	       -v "$PWD":"$cqfd_user_cwd" \
+	       -v "$cqfd_project_dir":"$cqfd_project_dir" \
 	       ${home_env_var:+ -e "$home_env_var"} \
 	       $interactive_options \
 	       ${SSH_AUTH_SOCK:+ -v $SSH_AUTH_SOCK:"$cqfd_user_home"/.sockets/ssh} \
@@ -355,10 +355,34 @@ EOF
 	echo $tmpfile
 }
 
+# locate_project_dir() - locate directory with .cqfd upwards
+# The directory will be printed on stdout, if found.
+locate_project_dir() {
+	local search_dir="$PWD"
+
+	while [ "$search_dir" != "/" ]; do
+		if [ -d "$search_dir"/"$cqfddir" ]; then
+			realpath "$search_dir"
+			return 0
+		fi
+		search_dir="$(readlink -f "$search_dir"/..)"
+	done
+
+	return 1
+}
+
 # config_load() - load build settings from cqfdrc
 # $1: optional "flavor" of the build, is a suffix of command.
 config_load() {
-	IFS="$IFS" parse_ini_config_file "$cqfdrc"
+	if ! cqfd_project_dir=$(locate_project_dir); then
+		die ".cqfd directory not found in directory tree"
+	fi
+
+	if ! $has_custom_cqfdrc; then
+		local cqfdrc_dir="$cqfd_project_dir/"
+	fi
+
+	IFS="$IFS" parse_ini_config_file "${cqfdrc_dir}${cqfdrc}"
 
 	cfg.section.project # load the [project] section
 	project_org="$org"
@@ -386,7 +410,7 @@ config_load() {
 	release_transform="$tar_transform"
 	release_tar_opts="$tar_options"
 
-	dockerfile="${cqfddir}/${distro:-docker}/Dockerfile"
+	dockerfile="${cqfd_project_dir}/${cqfddir}/${distro:-docker}/Dockerfile"
 
 	if [ -z "$project_org" ] || [ -z "$project_name" ]; then
 		die "Please set project.org and project.name in .cqfdrc"
@@ -407,6 +431,7 @@ config_load() {
 	fi
 }
 
+has_custom_cqfdrc=false
 has_to_release=false
 while [ $# -gt 0 ]; do
 	case "$1" in
@@ -438,6 +463,7 @@ while [ $# -gt 0 ]; do
 		;;
 	-f)
 		shift
+		has_custom_cqfdrc=true
 		cqfdrc="$1"
 		;;
 	-C)

--- a/tests/03-cqfd_error
+++ b/tests/03-cqfd_error
@@ -2,11 +2,13 @@
 
 . "$(dirname $0)"/jtest.inc "$1"
 
+cqfd="$TDIR"/.cqfd/cqfd
+
 ################################################################################
 # Running cqfd with an unknown argument shall fail
 ################################################################################
 jtest_prepare "run a bad cqfd command-line shall fail"
-if $TDIR/.cqfd/cqfd thisshouldfail; then
+if "$cqfd" invalid_arg_should_fail; then
 	jtest_result fail
 else
 	jtest_result pass
@@ -15,11 +17,18 @@ fi
 ################################################################################
 # Running cqfd without a .cqfdrc file in the current directory shall fail
 ################################################################################
-jtest_prepare "run with no config file shall fail"
-mkdir -p $TDIR/.empty/dir
-cd $TDIR/.empty/dir
-if $TDIR/.cqfd/cqfd run "echo Hello cqfd"; then
+jtest_prepare "'cfd run' with no config file shall fail"
+
+empty_dir=$(mktemp -d)
+pushd "$empty_dir" >/dev/null || exit 1
+
+if "$cqfd" run true; then
 	jtest_result fail
 else
 	jtest_result pass
 fi
+
+# cleanup
+popd >/dev/null || exit 1
+rm -rf "$empty_dir"
+

--- a/tests/05-cqfd_run_config
+++ b/tests/05-cqfd_run_config
@@ -5,54 +5,53 @@ cqfd="$TDIR/.cqfd/cqfd"
 confdir=$TDIR/.config/dir
 flavor="foo"
 
-cd $TDIR/
+cd "$TDIR" || exit 1
+
+# cp the default conf and replace the original with a fake one
+mkdir -p "$confdir"
+mv .cqfdrc "$confdir"/mycqfdrc
+touch .cqfdrc
 
 # First pass: run with non default config file
 # Second pass: run with non default config file and bash cmd
 # Third pass: run with non default config file and flavor
 # Fourth pass: run with flavor non default config file
-
-# cp the default conf and replace the original with a fake one
-mkdir -p $confdir
-mv .cqfdrc $confdir/mycqfdrc
-touch .cqfdrc
-
 for i in 0 1 2 3; do
-	jtest_log info "run cqfd with a non default file: $confdir/mycqfdrc, pass $i"
+	jtest_log info "cqfd run, custom cqfdrc: $confdir/mycqfdrc, pass $i"
 
 	case $i in
-		0)
-			test_file="a/cqfd_a.txt"
-			jtest_prepare "cqfd run with with this config file only"
-			$cqfd -f $confdir/mycqfdrc run
-			;;
-		1)
-			test_file="file.$RANDOM"
-			jtest_prepare "cqfd run and override with additionnal cmd"
-			$cqfd -f $confdir/mycqfdrc run touch $test_file
-			;;
-		2)
-			test_file=$flavor
-			jtest_prepare "cqfd run and build a given '$flavor' flavor"
-			$cqfd -f $confdir/mycqfdrc -b $flavor run touch $test_file
-			;;
-		3)
-			test_file=$flavor
-			jtest_prepare "cqfd run and build a given '$flavor' flavor (inverted args)"
-			$cqfd -b $flavor -f $confdir/mycqfdrc run touch $test_file
-			;;
-		*)
-			;;
+	0)
+		test_file="a/cqfd_a.txt" # from mycqfdrc
+		jtest_prepare "cqfd run with config in $confdir/mycqfdrc"
+		$cqfd -f "$confdir"/mycqfdrc run
+		;;
+	1)
+		test_file="file.$RANDOM"
+		jtest_prepare "cqfd run and override with additionnal cmd"
+		$cqfd -f "$confdir"/mycqfdrc run touch $test_file
+		;;
+	2)
+		test_file="$flavor.$RANDOM"
+		jtest_prepare "cqfd run and build a given '$flavor' flavor"
+		$cqfd -f "$confdir"/mycqfdrc -b $flavor run touch $test_file
+		;;
+	3)
+		test_file="$flavor.$RANDOM"
+		jtest_prepare "cqfd run and build a given '$flavor' flavor (inverted args)"
+		$cqfd -b $flavor -f "$confdir"/mycqfdrc run touch $test_file
+		;;
+	*)
+		;;
 	esac
 
-	if [ $? != 0 -o ! -f "$test_file" ]; then
+	if [ $? -ne 0 ] || [ ! -f "$test_file" ]; then
 		jtest_log fatal "failed or test file not present after execution"
 		jtest_result fail
 	else
 		jtest_result pass
 	fi
-	rm -f $test_file
+	rm -f "$test_file"
 done
 
 # restore for further tests
-mv $confdir/mycqfdrc .cqfdrc
+mv -f "$confdir"/mycqfdrc .cqfdrc

--- a/tests/05-cqfd_run_from_subdirectory
+++ b/tests/05-cqfd_run_from_subdirectory
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+. "$(dirname $0)"/jtest.inc "$1"
+cqfd="$TDIR/.cqfd/cqfd"
+
+jtest_prepare "cqfd can run from a project's sub-directory"
+
+pushd "$TDIR" >/dev/null || exit 1
+
+# Create and enter a dummy sub-directory tree
+sub_dir="dir with space/b/c/d/e"
+mkdir -p "$sub_dir"
+pushd "$sub_dir" >/dev/null || exit 1
+
+# the two paths should be identical
+p1=$(pwd | strings)
+p2=$($cqfd run pwd | strings)
+
+if [ "$p1" = "$p2" ]; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
+# cleanup
+popd >/dev/null || exit 1
+rm -rf aaa

--- a/tests/05-cqfd_run_spaces_in_path
+++ b/tests/05-cqfd_run_spaces_in_path
@@ -15,12 +15,12 @@ mkdir -p "$spaces_dir"/"$spaces_dir2"
 
 cp -a .cqfd .cqfdrc "$spaces_dir"/"$spaces_dir2"
 
-cd "$spaces_dir"/"$spaces_dir2"
+pushd "$spaces_dir"/"$spaces_dir2" >/dev/null || exit 1
 
 jtest_prepare "cqfd run from a directory with spaces"
 
 file="rand.$RANDOM"
-result=$($cqfd run touch $file)
+$cqfd run touch "$file"
 
 if [ -f "$file" ]; then
     rm -f "$file"
@@ -30,5 +30,5 @@ else
 fi
 
 # Teardown
-cd $TDIR
+popd >/dev/null || exit 1
 rm -rf "$spaces_dir"


### PR DESCRIPTION
In certain situations, it can be challenging to use cqfd when working from a sub-directory within our project. To address this, search for a configuration context by checking the parent directory hierarchy, similar to how git and other tools operate.
