### PR TITLE
Few Makefile improvement 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,5 +41,9 @@ uninstall:
 		rm -rf $(DESTDIR)$$completionsdir/cqfd; \
 	fi
 
+user-install user-uninstall:
+user-%:
+	$(MAKE) $* PREFIX=$$HOME/.local
+
 tests:
 	@make -C tests

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,10 @@ install:
 	install -m 0644 AUTHORS CHANGELOG.md LICENSE README.md $(DESTDIR)$(PREFIX)/share/doc/cqfd/
 	install -d $(DESTDIR)$(PREFIX)/share/cqfd/samples/
 	install -m 0644 samples/* $(DESTDIR)$(PREFIX)/share/cqfd/samples/
-	completionsdir=$$(pkg-config --variable=completionsdir bash-completion); \
+	completionsdir=$$(pkg-config --define-variable=prefix=$(PREFIX) \
+	                             --define-variable=datadir=$(PREFIX)/share \
+	                             --variable=completionsdir \
+	                             bash-completion); \
 	if [ -n "$$completionsdir" ]; then \
 		install -d $(DESTDIR)$$completionsdir/; \
 		install -m 644 bash-completion $(DESTDIR)$$completionsdir/cqfd; \
@@ -30,7 +33,10 @@ uninstall:
 	rm -rf $(DESTDIR)$(PREFIX)/bin/cqfd \
 		$(DESTDIR)$(PREFIX)/share/doc/cqfd \
 		$(DESTDIR)$(PREFIX)/share/cqfd
-	completionsdir=$$(pkg-config --variable=completionsdir bash-completion); \
+	completionsdir=$$(pkg-config --define-variable=prefix=$(PREFIX) \
+	                             --define-variable=datadir=$(PREFIX)/share \
+	                             --variable=completionsdir \
+	                             bash-completion); \
 	if [ -n "$$completionsdir" ]; then \
 		rm -rf $(DESTDIR)$$completionsdir/cqfd; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,10 @@ install:
 	install -m 0644 AUTHORS CHANGELOG.md LICENSE README.md $(DESTDIR)$(PREFIX)/share/doc/cqfd/
 	install -d $(DESTDIR)$(PREFIX)/share/cqfd/samples/
 	install -m 0644 samples/* $(DESTDIR)$(PREFIX)/share/cqfd/samples/
-	completionsdir=$$(pkg-config --define-variable=prefix=$(PREFIX) \
-	                             --define-variable=datadir=$(PREFIX)/share \
-	                             --variable=completionsdir \
-	                             bash-completion); \
+	completionsdir=$${COMPLETIONSDIR:-$$(pkg-config --define-variable=prefix=$(PREFIX) \
+	                                                --define-variable=datadir=$(PREFIX)/share \
+	                                                --variable=completionsdir \
+	                                                bash-completion)}; \
 	if [ -n "$$completionsdir" ]; then \
 		install -d $(DESTDIR)$$completionsdir/; \
 		install -m 644 bash-completion $(DESTDIR)$$completionsdir/cqfd; \
@@ -33,10 +33,10 @@ uninstall:
 	rm -rf $(DESTDIR)$(PREFIX)/bin/cqfd \
 		$(DESTDIR)$(PREFIX)/share/doc/cqfd \
 		$(DESTDIR)$(PREFIX)/share/cqfd
-	completionsdir=$$(pkg-config --define-variable=prefix=$(PREFIX) \
-	                             --define-variable=datadir=$(PREFIX)/share \
-	                             --variable=completionsdir \
-	                             bash-completion); \
+	completionsdir=$${COMPLETIONSDIR:-$$(pkg-config --define-variable=prefix=$(PREFIX) \
+	                                                --define-variable=datadir=$(PREFIX)/share \
+	                                                --variable=completionsdir \
+	                                                bash-completion)}; \
 	if [ -n "$$completionsdir" ]; then \
 		rm -rf $(DESTDIR)$$completionsdir/cqfd; \
 	fi


### PR DESCRIPTION
Hello,

I am using the target `user-install` for the last years as a convenient target to install projects to my home directory; mostly because I do not have enough privileges to install some development tools on some machines.

This PR consists of three commits:
 * fix the installation of the bash completion script to `${completionsdir}` using `$(PREFIX)` 
 * add `COMPLETIONSDIR` if the fix above is not enough for the package maintainers
 * add `user-install` target to install files to `~/.local` prefix
 
I hope this PR will be useful for developers.

Regards,
Gaël