### PR TITLE
Use grep -E instead of egrep

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -195,7 +195,7 @@ docker_run() {
 	# Set HOME variable for the $cqfd_user, except if it was
 	# explicitely set via CQFD_EXTRA_RUN_ARGS
 	local home_env_var="HOME=$cqfd_user_home"
-	if echo "$CQFD_EXTRA_RUN_ARGS" | egrep -q "(-e[[:blank:]]*|--env[[:blank:]]+)HOME="; then
+	if echo "$CQFD_EXTRA_RUN_ARGS" | grep -qE "(-e[[:blank:]]*|--env[[:blank:]]+)HOME="; then
 		home_env_var=""
 	fi
 

--- a/tests/03-cqfd_version
+++ b/tests/03-cqfd_version
@@ -33,7 +33,7 @@ fi
 ################################################################################
 jtest_prepare "cqfd version major number shall match the latest documented version"
 
-doc=$(grep '^## Version' $TDIR/CHANGELOG.md  | head -1 | egrep -Eo '[0-9.]+(-[a-z]+)?' | head -1)
+doc=$(grep '^## Version' $TDIR/CHANGELOG.md  | head -1 | grep -Eo '[0-9.]+(-[a-z]+)?' | head -1)
 version="$(cat $TEST)"
 
 if [ "$doc" = "$version" ]; then


### PR DESCRIPTION
This suppresses the warning below:

Fixes:

	egrep: warning: egrep is obsolescent; using grep -E