### PR TITLE
Generate dynamically the list of flavors

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -366,6 +366,7 @@ config_load() {
 	project_build_context="$build_context"
 
 	cfg.section.build # load the [build] section
+	build_flavors="$flavors"
 
 	# build parameters may be overriden by a flavor defined in the
 	# build section's 'flavors' parameter.
@@ -425,7 +426,7 @@ while [ $# -gt 0 ]; do
 		;;
 	flavors)
 		config_load
-		echo $flavors
+		echo $build_flavors
 		exit 0
 		;;
 	-b)

--- a/cqfd
+++ b/cqfd
@@ -360,6 +360,19 @@ EOF
 config_load() {
 	IFS="$IFS" parse_ini_config_file "$cqfdrc"
 
+	# generate dynamically the list of flavors based on the names of shell
+	# functions reported by the buildtin:
+	#  - the cfg.section. prefix is stripped
+	#  - the build and project sections are stripped
+	mapfile -t flavors < <(compgen -A function -X '!cfg.section.*')
+	flavors=("${flavors[@]/cfg.section./}")
+	for i in "${!flavors[@]}"; do
+		if [[ "${flavors[$i]}" =~ ^(build|project)$ ]]; then
+			unset 'flavors[$i]'
+		fi
+	done
+	flavors="${flavors[*]}"
+
 	cfg.section.project # load the [project] section
 	project_org="$org"
 	project_name="$name"


### PR DESCRIPTION
Hello,

This PR intends to reduce the cumbersome of maintaining the list of flavors if having lots of in the `.cqfdrc`.

The addition of the global variable `build_flavors` in the first commit is just for consistency with other properties. It does not harm much, and it may fix potential `flavor` override if additional sections are loaded before `cqfd flavors`, and if those sections (re)define the property `flavors`. This cannot happen for now.

Regards,
Gaël