### PR TITLE
cqfd: use su option --session-command

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -350,12 +350,11 @@ done
 # run the provided command in the working directory
 cd "$cqfd_user_cwd" || die "Changing directory to \"$cqfd_user_cwd\" failed."
 if [ -n "\$has_sudo" ]; then
-	# Use sudo to provide a controlling TTY for the executed command
 	debug "Using \"sudo\" to execute command \"\$@\" as user \"$cqfd_user\""
 	sudo -E -u $cqfd_user sh -c "\$@"
 else
 	debug "Using \"su\" to execute command \"\$@\" as user \"$cqfd_user\""
-	su $cqfd_user -p -c "\$@"
+	su $cqfd_user -p --session-command "\$@"
 fi
 EOF
 	echo $tmpfile


### PR DESCRIPTION
The sudo command controls its tty but su creates a new session and it does not.

According to man su(1):

	--session-command=command

	Same as -c, but do not create a new session. (Discouraged.)

This replaces the use of the option -c by --session-command to let su uses the same session.