### PR TITLE
bash-completion: fix completion for run arguments

### DIFF
--- a/bash-completion
+++ b/bash-completion
@@ -51,12 +51,17 @@ _cqfd() {
 	if [[ "$arg" == run ]]; then
 		for (( i=1; i <= cword; i++ )); do
 			if [[ ${words[i]} == run ]]; then
+				if [[ $((i+1)) -eq $cword ]]; then
+					break
+				elif [[ ${words[i+1]} == -c ]]; then
+					((i++))
+				fi
 				_command_offset $((i + 1))
 				return
 			fi
 		done
 
-		COMPREPLY=( $(compgen -c "$cur") )
+		COMPREPLY=( $(compgen -c -W "-c" -- "$cur") )
 		return
 	fi
 

--- a/bash-completion
+++ b/bash-completion
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (C) 2017 Savoir-faire Linux, Inc.
+# Copyright (C) 2017-2023 Savoir-faire Linux, Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -56,7 +56,7 @@ _cqfd() {
 		return
 	fi
 
-	local long_opts="init flavors run release version help"
-	COMPREPLY=( $(compgen -W "$long_opts $opts" -- "$cur") )
+	local cmds="init flavors run release version help"
+	COMPREPLY=( $(compgen -W "$cmds $opts" -- "$cur") )
 } &&
 complete -F _cqfd cqfd

--- a/bash-completion
+++ b/bash-completion
@@ -44,11 +44,21 @@ _cqfd() {
 	init|flavors|release|help)
 		return
 		;;
-	run)
+	esac
+
+	local arg=
+	_get_first_arg
+	if [[ "$arg" == run ]]; then
+		for (( i=1; i <= cword; i++ )); do
+			if [[ ${words[i]} == run ]]; then
+				_command_offset $((i + 1))
+				return
+			fi
+		done
+
 		COMPREPLY=( $(compgen -c "$cur") )
 		return
-		;;
-	esac
+	fi
 
 	local opts="-C -d -f -b -q -V --version -h --help"
 	if [[ "$cur" == -* ]]; then


### PR DESCRIPTION
The cqfd bash-completion script completes the run command as follow:
 - the argument following the run command completes for an host executable via `compgen -c` Note: this is correct at the exception it completes for an executable in the host system instead of the container
 - the arguments following the run command executable completes for the cqfd arguments, instead of completing for the run command executable arguments

Here is an example:

	$ cqfd run fdisk [hit tab]
	-b         -f         --help     -q         -V
	-C         flavors    help       release    --version
	-d         -h         init       run        version

And what it is expecting:

	$ cqfd run fdisk [hit tab]/dev/
	/dev/sda
	/dev/sda1
	/dev/sda2
	/dev/sdb
	/dev/sdb1

This uses the bash-completion function _command_offset() to complete if a run command executable is set.