### PR TITLE
cqfd: raise error if command= is unset but -c given

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -533,12 +533,14 @@ done
 
 config_load $flavor
 
+if [ -z "$build_cmd" ]; then
+	die "No build.command defined in $cqfdrc !"
+fi
+
 if [ -n "$build_cmd_alt" ]; then
 	build_cmd=$build_cmd_alt
 elif [ -n "$build_cmd_append" ]; then
 	build_cmd+=" $build_cmd_append"
-elif [ -z "$build_cmd" ]; then
-	die "No build.command defined in $cqfdrc !"
 fi
 
 docker_run "$build_cmd"


### PR DESCRIPTION
The option -c hides the misconfiguration if the command= is unset and the option -c and its argument are given to the command-line.

This fixes commit 5ea905903c6161d20a25fad43a55071d271254e7.