### PR TITLE
tests: strip down centos7 Dockerfile

### DIFF
--- a/tests/test_data/.cqfd/centos/Dockerfile
+++ b/tests/test_data/.cqfd/centos/Dockerfile
@@ -1,6 +1,2 @@
 FROM centos:centos7
 MAINTAINER The CentOS Project <cloud-ops@centos.org>
-
-RUN yum -y update
-
-


### PR DESCRIPTION
CentOS is discontinued.

Its Docker images are still available but the mirrors of the package repositories are dying one after the others.

As a consequence, installing or updating packages lasts like an eternity before the process ends with succeed or fails.

This strips down the centos Dockerfile to the bare minimun as there is no reason to test for update packages.