### PR TITLE
Clarify use of command string

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,8 @@
 
 # What is cqfd ? #
 
-cqfd provides a quick and convenient way to run commands in the current
-directory, but within a Docker container defined in a per-project config
-file.
+cqfd provides a quick and convenient way to run command string in the current
+directory, but within a Docker container defined in a per-project config file.
 
 This becomes useful when building an application designed for another
 Linux system, e.g. building an old embedded firmware that only works
@@ -37,12 +36,12 @@ does not have a systematic clean-up system in place.
 
 ### Regular builds ###
 
-To build your project from the configured build environment with the
-default build command as configured in .cqfdrc, use:
+To build your project from the configured build environment with the default
+build command string as configured in .cqfdrc, use:
 
     $ cqfd
 
-Alternatively, you may want to specify a custom build command to be
+Alternatively, you may want to specify a custom build command string to be
 executed from inside the build container.
 
     $ cqfd run make clean
@@ -55,9 +54,9 @@ has been stopped and removed.
 
 ### Release ###
 
-The release command behaves exactly like run, but creates a release
-tarball for your project additionally. The release files (as specified
-in your ``.cqfdrc``) will be included inside the release archive.
+The release command string behaves exactly like run, but creates a release
+tarball for your project additionally. The release files (as specified in your
+``.cqfdrc``) will be included inside the release archive.
 
     $ cqfd release
 
@@ -66,8 +65,8 @@ template, which defaults to ``%Po-%Pn.tar.xz``.
 
 ### Flavors ###
 
-Flavors are used to create alternate build scenarios. For example, to
-use another container or another build command.
+Flavors are used to create alternate build scenarios. For example, to use
+another container or another build command string.
 
 ## The .cqfdrc file ##
 
@@ -91,14 +90,13 @@ Here is a sample .cqfdrc file:
 
 ``name``: a short, lowercase name for the project.
 
-``build_context`` (optional): a directory to pass as the build context
-to Docker. This should be specified relatively to where cqfd is
-invoked.  For example, it can be set to `.`, to use the current
-working directory of the invoked `cqfd` command as the Docker build
-context, which can be useful when files at the root of the project are
-required to build the image.  When using this option, a
-``.dockerignore`` file can be useful to limit what gets sent to the
-Docker daemon.
+``build_context`` (optional): a directory to pass as the build context to
+Docker. This should be specified relatively to where cqfd is invoked. For
+example, it can be set to `.`, to use the current working directory of the
+invoked `cqfd` command string as the Docker build context, which can be useful
+when files at the root of the project are required to build the image. When
+using this option, a ``.dockerignore`` file can be useful to limit what gets
+sent to the Docker daemon.
 
 Generated Docker images for your project will be named $org_$name.
 
@@ -149,8 +147,8 @@ should be a member of in the container. You can either use the ``group:gid``
 format, or simply specify the ``group`` name if it exists either in the host or
 inside the docker image.
 
-``flavors``: the list of build flavors (see below). Each flavor has its
-own command just like build.command.
+``flavors``: the list of build flavors (see below). Each flavor has its own
+command string just like build.command.
 
 ``docker_run_args`` (optional): arguments used to invoke `docker run`.
 For example, to share networking with the host, it can be set like:

--- a/cqfd
+++ b/cqfd
@@ -44,15 +44,15 @@ Options:
 Commands:
     init     Initialize project build container
     flavors  List flavors from config file to stdout
-    run      Run argument(s) inside build container
-    release  Run argument(s) and release software
+    run      Run command string inside build container
+    release  Run command string and release software
     help     Show this help text
 
-    By default, run is assumed, and the run command is the one
+    By default, run is assumed, and the run command string is the one
     configured in .cqfdrc.
 
 Command options for run / release:
-    -c <args>      Append args to the default command
+    -c <string>         Append string to the default command string
 
     cqfd is Copyright (C) 2015-2023 Savoir-faire Linux, Inc.
 
@@ -120,10 +120,10 @@ docker_build() {
 	fi
 }
 
-# docker_run() - run command in configured container
+# docker_run() - run command string in configured container
 # A few implementation details:
 #
-# - The user executing the build commands inside the container is
+# - The user executing the build command string inside the container is
 #   named after $cqfd_user, with the same uid/gid as your user to keep
 #   filesystem permissions in sync.
 #
@@ -347,15 +347,15 @@ for g in ${CQFD_GROUPS}; do
 	usermod -a -G \$group $cqfd_user || die "usermod command failed while adding group \${group}."
 done
 
-# run the provided command in the working directory
+# run the provided command string in the working directory
 cd "$cqfd_user_cwd" || die "Changing directory to \"$cqfd_user_cwd\" failed."
 if [ -n "\$has_sudo" ]; then
-	# Use sudo to provide a controlling TTY for the executed command
-	debug "Using \"sudo\" to execute command \"\$@\" as user \"$cqfd_user\""
-	sudo -E -u $cqfd_user sh -c "\$@"
+	# Use sudo to provide a controlling TTY for the executed command string
+	debug "Using \"sudo\" to execute command string \"\$1\" as user \"$cqfd_user\""
+	sudo -E -u $cqfd_user sh -c "\$1"
 else
-	debug "Using \"su\" to execute command \"\$@\" as user \"$cqfd_user\""
-	su $cqfd_user -p -c "\$@"
+	debug "Using \"su\" to execute command string \"\$1\" as user \"$cqfd_user\""
+	su $cqfd_user -p -c "\$1"
 fi
 EOF
 	echo $tmpfile
@@ -501,10 +501,10 @@ while [ $# -gt 0 ]; do
 
 		shift
 
-		# No more args? run default command
+		# No more args? run default command string
 		[ "$#" -eq 0 ] && break
 
-		# -c appends following args to the default command
+		# -c appends following args to the default command string
 		if [ "$1" = "-c" ]; then
 			if [ $# -lt 2 ]; then
 				die "option -c requires arguments"
@@ -515,7 +515,7 @@ while [ $# -gt 0 ]; do
 			break
 		fi
 
-		# Run alternate command
+		# Run alternate command string
 		build_cmd_alt="$*"
 		break
 		;;

--- a/cqfd
+++ b/cqfd
@@ -220,7 +220,7 @@ docker_run() {
 	       $interactive_options \
 	       ${SSH_AUTH_SOCK:+ -v $SSH_AUTH_SOCK:"$cqfd_user_home"/.sockets/ssh} \
 	       ${SSH_AUTH_SOCK:+ -e SSH_AUTH_SOCK="$cqfd_user_home"/.sockets/ssh} \
-	       $docker_img_name cqfd_launch "$@" 2>&1
+	       $docker_img_name cqfd_launch "$1" 2>&1
 }
 
 # make_archive(): Create a release package.
@@ -516,7 +516,7 @@ while [ $# -gt 0 ]; do
 		fi
 
 		# Run alternate command
-		build_cmd_alt="$@"
+		build_cmd_alt="$*"
 		break
 		;;
 	?*)


### PR DESCRIPTION
Dear Maintainer,

This PR intends to clarify the use for the command given to docker-run.

The command run is `command_string` that is interpreted  by a shell, i.e. including the shell grammar, variables...

This `command_string` is taken from the `.cqdrc` attribute `command=` or from the `cqfd run` command line (as a string "$*"), and it is given to `/bin/sh -c`, therefore, it **MUST** be a single argument.

Best Regards,
Gaël