### PR TITLE
cqfd: fix syntax

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -294,8 +294,7 @@ make_archive() {
 
 # make_launcher - generate in-container launcher script
 # return: the path to the launcher script on stdout
-make_launcher()
-{
+make_launcher() {
 	local tmpfile=$(mktemp /tmp/tmp.XXXXXX)
 
 	chmod 0755 $tmpfile
@@ -303,16 +302,16 @@ make_launcher()
 #!/bin/sh
 # create container user to match expected environment
 
-die () {
+die() {
 	echo "error: \$*"
 	exit 1
 }
 
-test_cmd () {
+test_cmd() {
 	command -v "\$1" > /dev/null 2>&1
 }
 
-debug () {
+debug() {
       test -n "\$CQFD_DEBUG" && echo "debug: \$*"
 }
 

--- a/cqfd
+++ b/cqfd
@@ -37,7 +37,7 @@ Options:
     -d <directory>      Use directory as cqfd directory (default .cqfd).
     -C <directory>      Use the specified working directory.
     -b <flavor_name>    Target a specific build flavor.
-    -q                  Turn on quiet mode
+    -q                  Turn on quiet mode.
     -v or --version     Show version.
     -h or --help        Show this help text.
 
@@ -52,7 +52,7 @@ Commands:
     configured in .cqfdrc.
 
 Command options for run / release:
-    -c <args>      Append args to the default command
+    -c <args>      Append args to the default command.
 
     cqfd is Copyright (C) 2015-2023 Savoir-faire Linux, Inc.
 


### PR DESCRIPTION
Most of the functions in the script do not use a space between the name and the parenthesis, and opens the curving brace in the same line.

This fixes syntax by removing the spaces between the function name and its parenthesis and opening the curging brace in the same line for the sake of consistancy.