### PR TITLE
Use $1 and $* instead of "$@"

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -220,7 +220,7 @@ docker_run() {
 	       $interactive_options \
 	       ${SSH_AUTH_SOCK:+ -v $SSH_AUTH_SOCK:"$cqfd_user_home"/.sockets/ssh} \
 	       ${SSH_AUTH_SOCK:+ -e SSH_AUTH_SOCK="$cqfd_user_home"/.sockets/ssh} \
-	       $docker_img_name cqfd_launch "$@" 2>&1
+	       $docker_img_name cqfd_launch "$1" 2>&1
 }
 
 # make_archive(): Create a release package.
@@ -514,7 +514,7 @@ while [ $# -gt 0 ]; do
 		fi
 
 		# Run alternate command
-		build_cmd_alt="$@"
+		build_cmd_alt="$*"
 		break
 		;;
 	?*)


### PR DESCRIPTION
The function docker_run() takes a single argument as the command string, but it uses "$@". Therefore, $1 is enough and it should be used instead to avoid confusion.

The shell expression "$@" expands to an array string, but the "$@" is assigned to the scalar (i.e. non-array) variable build_cmd_alt; Therefore, $* should be used instead.

This uses $1 and $* instead of "$@" at some places.