### PR TITLE
Fix unsupported su session command

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -349,10 +349,10 @@ done
 # run provided command in the working directory
 cd "$cqfd_user_cwd" || die "Changing directory to \"$cqfd_user_cwd\" failed."
 if [ -n "\$has_sudo" ]; then
-	debug "Using \"sudo\" to execute command \"\$1\" as user \"$cqfd_user\""
+	debug "Using \"sudo\" to execute command sh -c \"\$1\" as user \"$cqfd_user\""
 	sudo -E -u $cqfd_user sh -c "\$1"
 else
-	debug "Using \"su\" to execute command \"\$1\" as user \"$cqfd_user\""
+	debug "Using \"su\" to execute session command \"\$1\" as user \"$cqfd_user\""
 	su $cqfd_user -p --session-command "\$1"
 fi
 EOF

--- a/cqfd
+++ b/cqfd
@@ -311,6 +311,10 @@ test_cmd() {
 	command -v "\$1" > /dev/null 2>&1
 }
 
+test_su_session_command() {
+	su --session-command true > /dev/null 2>&1
+}
+
 debug() {
       test -n "\$CQFD_DEBUG" && echo "debug: \$*"
 }
@@ -325,6 +329,7 @@ test_cmd sudo && has_sudo=1 || test_cmd su ||
 	{ failed=1 && echo "error: Missing command: su or sudo"; }
 test -n "\$failed" &&
 	die "Some dependencies are missing from the container, see above messages."
+test_su_session_command && has_su_session_command=1
 
 # Add the host's user and group to the container, and adjust ownership.
 groupadd -og $GROUPS -f builders || die "groupadd command failed."
@@ -351,9 +356,12 @@ cd "$cqfd_user_cwd" || die "Changing directory to \"$cqfd_user_cwd\" failed."
 if [ -n "\$has_sudo" ]; then
 	debug "Using \"sudo\" to execute command sh -c \"\$1\" as user \"$cqfd_user\""
 	sudo -E -u $cqfd_user sh -c "\$1"
-else
+elif [ -n "\$has_su_session_command" ]; then
 	debug "Using \"su\" to execute session command \"\$1\" as user \"$cqfd_user\""
 	su $cqfd_user -p --session-command "\$1"
+else
+	debug "Using \"su\" to execute command \"\$1\" as user \"$cqfd_user\""
+	su $cqfd_user -p -c "\$1"
 fi
 EOF
 	echo $tmpfile

--- a/tests/05-cqfd_run_check_dependencies
+++ b/tests/05-cqfd_run_check_dependencies
@@ -2,6 +2,8 @@
 #
 # validate the behavior of project.build_context
 
+set -o pipefail
+
 . $(dirname "$0")/jtest.inc "$1"
 cqfd="$TDIR/.cqfd/cqfd"
 

--- a/tests/05-cqfd_run_su_or_sudo_backend
+++ b/tests/05-cqfd_run_su_or_sudo_backend
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# validate the behavior of run command su and sudo backends
+
+set -o pipefail
+
+. $(dirname "$0")/jtest.inc "$1"
+cqfd="$TDIR/.cqfd/cqfd"
+
+cd $TDIR/
+
+################################################################################
+# Use a custom Dockerfile with an ancient version of su.
+################################################################################
+cp -f .cqfd/docker/Dockerfile .cqfd/docker/Dockerfile.orig
+echo "FROM ubuntu:16.04" > .cqfd/docker/Dockerfile
+echo "ENV CQFD_DEBUG=1" >> .cqfd/docker/Dockerfile
+
+################################################################################
+# cqfd run should be happy using su -c.
+################################################################################
+jtest_prepare "cqfd run with su -c"
+$cqfd init && \
+    $cqfd run true \
+	| awk -v rc=1 '/Using "su" to execute command/ { rc=0 } 1; END {exit rc}' \
+    && jtest_result pass || jtest_result fail
+
+################################################################################
+# Use another custom Dockerfile with a recent version of su.
+################################################################################
+echo "FROM ubuntu:20.04" > .cqfd/docker/Dockerfile
+echo "ENV CQFD_DEBUG=1" >> .cqfd/docker/Dockerfile
+
+################################################################################
+# cqfd run should be happy using su --session-command.
+################################################################################
+jtest_prepare "cqfd run with su --session-command"
+$cqfd init && \
+    $cqfd run true \
+	| awk -v rc=1 '/Using "su" to execute session command/ { rc=0 } 1; END {exit rc}' \
+    && jtest_result pass || jtest_result fail
+
+################################################################################
+# Install the sudo package.
+################################################################################
+echo "ENV DEBIAN_FRONTEND noninteractive" >> .cqfd/docker/Dockerfile
+echo "RUN apt-get update && apt-get install -y --no-install-recommends sudo" >> .cqfd/docker/Dockerfile
+
+################################################################################
+# cqfd run should be happy using sudo.
+################################################################################
+jtest_prepare "cqfd run with sudo"
+$cqfd init && \
+    $cqfd run true \
+	| awk -v rc=1 '/Using "sudo" to execute command/ { rc=0 } 1; END {exit rc}' \
+    && jtest_result pass || jtest_result fail
+
+################################################################################
+# Restore initial Dockerfile.
+################################################################################
+mv -f .cqfd/docker/Dockerfile.orig .cqfd/docker/Dockerfile
+$cqfd init


### PR DESCRIPTION
Hello @joufella,

I figured out that the option `--session-command` is unsupported on Ubuntu 16.04.

This addresses the following error:

```
$ cqfd
su: unrecognized option '--session-command'
Usage: su [options] [LOGIN]

Options:
  -c, --command COMMAND         pass COMMAND to the invoked shell
  -h, --help                    display this help message and exit
  -, -l, --login                make the shell a login shell
  -m, -p,
  --preserve-environment        do not reset environment variables, and
                                keep the same shell
  -s, --shell SHELL             use SHELL instead of the default in passwd
  ```

Sorry for the inconvenience.

Regards,
Gaël