### PR TITLE
cqfd: minor alignment in usage function

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -53,7 +53,7 @@ Commands:
     command string configured in your .cqfdrc (see build.command).
 
 Command options for run / release:
-    -c <args>             Append args to the default command string.
+    -c <args>            Append args to the default command string.
 
     cqfd is Copyright (C) 2015-2024 Savoir-faire Linux, Inc.
 


### PR DESCRIPTION
This fixes a minor nitpick in the alignment of the run option -c if usage is to be output.