### PR TITLE
Revert "cqfd: redirect command stderr to stdout" once again

### DIFF
--- a/tests/05-cqfd_init_extra_env
+++ b/tests/05-cqfd_init_extra_env
@@ -35,6 +35,6 @@ else
 fi
 
 ################################################################################
-# restore initial .cqfdrc and Dockerfile
+# restore initial Dockerfile
 ################################################################################
 mv -f .cqfd/docker/Dockerfile.orig .cqfd/docker/Dockerfile

--- a/tests/05-cqfd_run_extra_groups
+++ b/tests/05-cqfd_run_extra_groups
@@ -5,6 +5,9 @@ cqfd="$TDIR/.cqfd/cqfd"
 
 cd $TDIR/
 
+cqfdrc_old=$(mktemp)
+cp -f .cqfdrc "$cqfdrc_old"
+
 ################################################################################
 # 'cqfd run' should add extra_groups provided by an environment variable
 ################################################################################
@@ -30,3 +33,4 @@ else
 	jtest_result fail
 fi
 
+mv -f "$cqfdrc_old" .cqfdrc

--- a/tests/05-cqfd_run_extra_hosts
+++ b/tests/05-cqfd_run_extra_hosts
@@ -38,4 +38,4 @@ else
 fi
 
 # teardown -- clear the docker_run_args option from config
-sed 's/docker_run_args.*//' -i "$TDIR/.cqfdrc"
+sed '/\[build\]/{n;d}' -i "$TDIR/.cqfdrc"

--- a/tests/05-cqfd_run_whitespace_resiliency
+++ b/tests/05-cqfd_run_whitespace_resiliency
@@ -34,4 +34,4 @@ else
 fi
 
 # teardown -- clear the docker_run_args option from config
-sed 's/^docker_run_args=.*//' -i "$TDIR/.cqfdrc"
+sed '/\[build\]/{n;d}' -i "$TDIR/.cqfdrc"

--- a/tests/06-cqfd_release
+++ b/tests/06-cqfd_release
@@ -5,6 +5,9 @@ cqfd="$TDIR/.cqfd/cqfd"
 
 cd $TDIR/
 
+cqfdrc_old=$(mktemp)
+cp -f .cqfdrc "$cqfdrc_old"
+
 ################################################################################
 # The first invocation has no 'files' parameter defined,
 # hence it should fail
@@ -211,3 +214,4 @@ fi
 
 # cleanup
 rm -f tmp.$$ cqfd-$CTEST.tar.xz
+mv -f "$cqfdrc_old" .cqfdrc

--- a/tests/09-cqfd-pts
+++ b/tests/09-cqfd-pts
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# validate the allocation of pty and the behavior of redirections
+
+. "$(dirname "$0")/jtest.inc" "$1"
+cqfd="$TDIR/.cqfd/cqfd"
+
+cd "$TDIR/"
+
+cqfdrc_old=$(mktemp)
+cp -f .cqfdrc "$cqfdrc_old"
+sed -i -e "/\[build\]/,/^$/s/^command=.*$/command='tty || true'/" .cqfdrc
+$cqfd init
+
+jtest_prepare "cqfd without redirection should allocate a tty"
+if $cqfd | grep "/dev/pts/1" ; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
+jtest_prepare "cqfd with stdin redirected to /dev/null should not allocate a pty"
+if $cqfd </dev/null | grep 'not a tty'; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
+jtest_prepare "cqfd with stderr redirected to /dev/null should not allocate a pty"
+if $cqfd 2>/dev/null | grep 'not a tty'; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
+sed -i -e "/\[build\]/,/^$/s,^command=.*$,command='echo stdout \&\& echo stderr >\&2'," .cqfdrc
+$cqfd init
+
+jtest_prepare "cqfd with allocated pty should redirect stdout and stderr to same endpoint"
+if $cqfd >out; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+rm out
+
+jtest_prepare "cqfd without allocated pty should redirect stdout and stderr to distinct entpoints"
+if $cqfd >out 2>err && grep 'stdout' out && grep 'stderr' err; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+rm out err
+
+mv -f "$cqfdrc_old" .cqfdrc


### PR DESCRIPTION
This reverts commit 0cef50e9a93545c91b2beaf9842f76fafcd235d3 once again.

The commit e8bc9afb3381800c7f92045c6aa26f167802baa6 has mistakenly reverted the change ae5c830e236466fc5d8ad42e6eca19bf371945db.