### PR TITLE
Revert "tests: check that the returned version matches the doc"

### DIFF
--- a/tests/00-setup
+++ b/tests/00-setup
@@ -6,7 +6,6 @@ jtest_prepare "create a test skeleton in temporary directory"
 
 mkdir -p $TDIR/.cqfd/docker
 cp -a ../cqfd $TDIR/.cqfd/
-cp -a ../CHANGELOG.md $TDIR/.
 cp -a test_data/. $TDIR/.
 
 cd $TDIR/

--- a/tests/03-cqfd_version
+++ b/tests/03-cqfd_version
@@ -28,20 +28,4 @@ cat $TEST >&2
 	jtest_result fail
 fi
 
-################################################################################
-# 'cqfd version' shall match the latest documented version
-################################################################################
-doc=$(grep '^## Version' $TDIR/CHANGELOG.md  | head -1 | grep -Eo '[0-9.]+(-[a-z]+)?' | head -1)
-version="$(cat $TEST)"
-
-jtest_prepare "cqfd version ($version) matches latest one in CHANGELOG ($doc)"
-
-if [ "$doc" = "$version" ]; then
-	jtest_result pass
-else
-	jtest_log error "version major number doesn't match the doc"
-cat "$TEST" >&2
-	jtest_result fail
-fi
-
 rm -f "$TEST"


### PR DESCRIPTION
This reverts commit 06be9e566d13a8a82f910afb74e00fe450663b2f.

The test is broken since 73122a887ff58b67fb9d5e783652186ff980a0d3.

	[02:21:47|notice] preparing "cqfd version (5.5.1-dev) matches latest one in CHANGELOG (5.5.0)"
	[02:21:47|error] version major number doesn't match the doc
	5.5.1-dev
	[02:21:47|info] result: cqfd version (5.5.1-dev) matches latest one in CHANGELOG (5.5.0): FAIL
	[02:21:47|info] -----------------------------------------------------

This test is not relevant, drop it!