### PR TITLE
Few parse_ini_config_file() fixes

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -84,8 +84,8 @@ parse_ini_config_file() {
 	ini="${ini//]/\\]}"                               # escape ]
 	IFS=$'\n' && ini=( ${ini} )                       # convert to line-array
 	ini=( ${ini[*]//;*/} )                            # remove comments with ;
-	ini=( ${ini[*]/\    =/=} )                        # remove tabs before =
-	ini=( ${ini[*]/=\   /=} )                         # remove tabs after =
+	ini=( ${ini[*]/$'\t'=/=} )                        # remove tabs before =
+	ini=( ${ini[*]/=$'\t'/=} )                        # remove tabs after =
 	ini=( ${ini[*]/\ =\ /=} )                         # remove anything with a space around =
 	ini=( ${ini[*]/#\\[/\}$'\n'cfg.section.} )        # set section prefix
 	ini=( ${ini[*]/%\\]/ \(} )                        # convert text2function (1)

--- a/cqfd
+++ b/cqfd
@@ -85,7 +85,7 @@ parse_ini_config_file() {
 	IFS=$'\n' && ini=( ${ini} )                       # convert to line-array
 	ini=( ${ini[*]//;*/} )                            # remove comments with ;
 	ini=( ${ini[*]/\    =/=} )                        # remove tabs before =
-	ini=( ${ini[*]/=\   /=} )                         # remove tabs be =
+	ini=( ${ini[*]/=\   /=} )                         # remove tabs after =
 	ini=( ${ini[*]/\ =\ /=} )                         # remove anything with a space around =
 	ini=( ${ini[*]/#\\[/\}$'\n'cfg.section.} )        # set section prefix
 	ini=( ${ini[*]/%\\]/ \(} )                        # convert text2function (1)

--- a/cqfd
+++ b/cqfd
@@ -79,22 +79,22 @@ parse_ini_config_file() {
 		die "Can't find $1 - create it or pick one using 'cqfd -f'"
 	fi
 
-	ini="$(<"$1")"               # read the file
-	ini="${ini//[/\\[}"          # escape [
-	ini="${ini//]/\\]}"          # escape ]
-	IFS=$'\n' && ini=( ${ini} )  # convert to line-array
-	ini=( ${ini[*]//;*/} )       # remove comments with ;
-	ini=( ${ini[*]/\    =/=} )   # remove tabs before =
-	ini=( ${ini[*]/=\   /=} )    # remove tabs be =
-	ini=( ${ini[*]/\ =\ /=} )    # remove anything with a space around =
-	ini=( ${ini[*]/#\\[/\}$'\n'cfg.section.} ) # set section prefix
-	ini=( ${ini[*]/%\\]/ \(} )       # convert text2function (1)
-	ini=( ${ini[*]/%\(/ \( \)} )     # close array parenthesis
-	ini=( ${ini[*]/%\\ \)/ \\} )     # the multiline trick
-	ini=( ${ini[*]/%\( \)/\(\) \{} ) # convert text2function (2)
-	ini=( ${ini[*]/%\} \)/\}} )      # remove extra parenthesis
-	ini[0]=""                        # remove first element
-	ini[${#ini[*]} + 1]='}'          # add the last brace
+	ini="$(<"$1")"                                    # read the file
+	ini="${ini//[/\\[}"                               # escape [
+	ini="${ini//]/\\]}"                               # escape ]
+	IFS=$'\n' && ini=( ${ini} )                       # convert to line-array
+	ini=( ${ini[*]//;*/} )                            # remove comments with ;
+	ini=( ${ini[*]/\    =/=} )                        # remove tabs before =
+	ini=( ${ini[*]/=\   /=} )                         # remove tabs be =
+	ini=( ${ini[*]/\ =\ /=} )                         # remove anything with a space around =
+	ini=( ${ini[*]/#\\[/\}$'\n'cfg.section.} )        # set section prefix
+	ini=( ${ini[*]/%\\]/ \(} )                        # convert text2function (1)
+	ini=( ${ini[*]/%\(/ \( \)} )                      # close array parenthesis
+	ini=( ${ini[*]/%\\ \)/ \\} )                      # the multiline trick
+	ini=( ${ini[*]/%\( \)/\(\) \{} )                  # convert text2function (2)
+	ini=( ${ini[*]/%\} \)/\}} )                       # remove extra parenthesis
+	ini[0]=""                                         # remove first element
+	ini[${#ini[*]} + 1]='}'                           # add the last brace
 	if ! eval "$(echo "${ini[*]}")" 2>/dev/null; then # eval the result
 		die "$1: Invalid ini-file!"
 	fi

--- a/cqfd
+++ b/cqfd
@@ -86,7 +86,8 @@ parse_ini_config_file() {
 	ini=( ${ini[*]//;*/} )                            # remove comments with ;
 	ini=( ${ini[*]/$'\t'=/=} )                        # remove tabs before =
 	ini=( ${ini[*]/=$'\t'/=} )                        # remove tabs after =
-	ini=( ${ini[*]/\ =\ /=} )                         # remove anything with a space around =
+	ini=( ${ini[*]/\ =/=} )                           # remove space before =
+	ini=( ${ini[*]/=\ /=} )                           # remove space after =
 	ini=( ${ini[*]/#\\[/\}$'\n'cfg.section.} )        # set section prefix
 	ini=( ${ini[*]/%\\]/ \(} )                        # convert text2function (1)
 	ini=( ${ini[*]/%\(/ \( \)} )                      # close array parenthesis

--- a/tests/03-cqfdrc_error
+++ b/tests/03-cqfdrc_error
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# validate the .cqfdrc syntax
+
+. "$(dirname "$0")"/jtest.inc "$1"
+cqfd="$TDIR/.cqfd/cqfd"
+
+cd $TDIR/
+
+cqfdrc_old=$(mktemp)
+cp -f .cqfdrc "$cqfdrc_old"
+echo "foo	=bar" >>.cqfdrc
+
+jtest_prepare "cqfdrc with tabulation before should pass"
+if $cqfd run true; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
+cp -f "$cqfdrc_old" .cqfdrc
+echo "foo=	bar" >>.cqfdrc
+
+jtest_prepare "cqfdrc with tabulation after should pass"
+if $cqfd run true; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
+mv -f "$cqfdrc_old" .cqfdrc

--- a/tests/03-cqfdrc_error
+++ b/tests/03-cqfdrc_error
@@ -28,4 +28,24 @@ else
 	jtest_result fail
 fi
 
+cp -f "$cqfdrc_old" .cqfdrc
+echo "foo =bar" >>.cqfdrc
+
+jtest_prepare "cqfdrc with space before should pass"
+if $cqfd run true; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
+cp -f "$cqfdrc_old" .cqfdrc
+echo "foo= bar" >>.cqfdrc
+
+jtest_prepare "cqfdrc with space after should pass"
+if $cqfd run true; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
 mv -f "$cqfdrc_old" .cqfdrc


### PR DESCRIPTION
Hello,

This fixes some issues found in the mechanism of ini-translation-to-bash.

I am a bit worry if the fix about the removal of (single) space before sign `=`, or after sign `=` (but not both) and if true tabulation before and after the sign `=` will break things to users since it never worked.

Maybe, we could simply drops that feature of stripping (single) whitespaces arround `=`.

What do you think?