### PR TITLE
More options for SSH, GIT and SHELL

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,10 +213,13 @@ docker-build options to be append to the building image.
 Format is the same as (and passed to) docker-build’s options.
 See 'docker build --help'.
 
-``CQFD_NO_SSH_CONFIG``: Set to ``true`` to disable forwarding
-the user's ``~/.ssh`` and global ``/etc/ssh`` configurations to the
-container. This may be required if the host's ``ssh`` configuration
-is not compatible with the ``ssh`` version within the container.
+``CQFD_NO_SSH_CONFIG``: Set to ``true`` to disable forwarding the global
+``/etc/ssh`` configurations to the container. This may be required if
+the host's ``ssh`` configuration is not compatible with the ``ssh``
+version within the container.
+
+``CQFD_NO_USER_SSH_CONFIG``: Set to ``true`` to disable forwarding
+the user's ``~/.ssh`` configuration to the container.
 
 ### Appending to the build command ###
 

--- a/README.md
+++ b/README.md
@@ -221,6 +221,9 @@ version within the container.
 ``CQFD_NO_USER_SSH_CONFIG``: Set to ``true`` to disable forwarding
 the user's ``~/.ssh`` configuration to the container.
 
+``CQFD_NO_USER_GIT_CONFIG``: Set to ``true`` to disable forwarding
+the user's ``~/.gitconfig`` configuration to the container.
+
 ### Appending to the build command ###
 
 The `-c` option allows appending the command of a cqfd run for temporary developments:

--- a/README.md
+++ b/README.md
@@ -224,6 +224,8 @@ the user's ``~/.ssh`` configuration to the container.
 ``CQFD_NO_USER_GIT_CONFIG``: Set to ``true`` to disable forwarding
 the user's ``~/.gitconfig`` configuration to the container.
 
+``CQFD_SHELL``: The shell to be launched, by default ``/bin/sh``.
+
 ### Appending to the build command ###
 
 The `-c` option allows appending the command of a cqfd run for temporary developments:

--- a/bash-completion
+++ b/bash-completion
@@ -15,6 +15,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+if [ -z "$BASH_VERSION" ]; then
+	_init_completion() {
+	}
+	_get_first_arg() {
+	}
+fi
+
 _cqfd() {
 	local cur prev words cword
 	_init_completion || return

--- a/cqfd
+++ b/cqfd
@@ -250,6 +250,10 @@ docker_run() {
 		args+=(-e "SSH_AUTH_SOCK=$cqfd_user_home/.sockets/ssh")
 	fi
 
+	if [ "$CQFD_NO_USER_GIT_CONFIG" != true ]; then
+		args+=(-v "$cqfd_user_home/.gitconfig:$cqfd_user_home/.gitconfig")
+	fi
+
 	args+=(-v "$cqfd_project_dir:$cqfd_project_dir")
 
 	tmp_launcher=$(make_launcher)

--- a/cqfd
+++ b/cqfd
@@ -40,6 +40,7 @@ Options:
     -b <flavor_name>     Target a specific build flavor.
     -q                   Turn on quiet mode.
     -v or --version      Show version.
+    --verbose            Increase the script's verbosity.
     -h or --help         Show this help text.
 
 Commands:
@@ -113,11 +114,18 @@ die() {
 	exit 1
 }
 
+## debug() - print verbose messages
+debug() {
+	test -n "$CQFD_DEBUG" && echo "cqfd: debug: $*" || true
+}
+
 # docker_build() - Initialize build container
 docker_build() {
 	if [ -z "$project_build_context" ]; then
+		debug executing: docker build ${quiet:+-q} $CQFD_EXTRA_BUILD_ARGS -t "$docker_img_name" "$(dirname "$dockerfile")"
 		docker build ${quiet:+-q} $CQFD_EXTRA_BUILD_ARGS -t "$docker_img_name" "$(dirname "$dockerfile")"
 	else
+		debug executing: docker build ${quiet:+-q} $CQFD_EXTRA_BUILD_ARGS -t "$docker_img_name" "${project_build_context}" -f "$dockerfile"
 		docker build ${quiet:+-q} $CQFD_EXTRA_BUILD_ARGS -t "$docker_img_name" "${project_build_context}" -f "$dockerfile"
 	fi
 }
@@ -264,6 +272,7 @@ docker_run() {
 
 	args+=("$docker_img_name" cqfd_launch "$1")
 
+	debug executing: docker run "${args[@]}"
 	docker run "${args[@]}"
 }
 
@@ -519,6 +528,9 @@ while [ $# -gt 0 ]; do
 	version|-v|"--version")
 		echo $VERSION
 		exit 0
+		;;
+	"--verbose")
+		export CQFD_DEBUG=true
 		;;
 	init)
 		config_load $flavor

--- a/cqfd
+++ b/cqfd
@@ -237,8 +237,11 @@ docker_run() {
 		args+=(-e "$home_env_var")
 	fi
 
-	if [ "$CQFD_NO_SSH_CONFIG" != true ]; then
+	if [ "$CQFD_NO_USER_SSH_CONFIG" != true ]; then
 		args+=(-v "$cqfd_user_home/.ssh:$cqfd_user_home/.ssh")
+	fi
+
+	if [ "$CQFD_NO_SSH_CONFIG" != true ]; then
 		args+=(-v /etc/ssh:/etc/ssh)
 	fi
 

--- a/cqfd
+++ b/cqfd
@@ -376,7 +376,7 @@ test_su_session_command && has_su_session_command=1
 
 # Add the host's user and group to the container, and adjust ownership.
 groupadd -og $GROUPS -f builders || die "groupadd command failed."
-useradd -s /bin/sh -oN -u $UID -g $GROUPS -d "$cqfd_user_home" $cqfd_user \
+useradd -s ${CQFD_SHELL:-/bin/sh} -oN -u $UID -g $GROUPS -d "$cqfd_user_home" $cqfd_user \
 	|| die "useradd command failed."
 mkdir -p "$cqfd_user_home" || die "mkdir command failed."
 chown $UID:$GROUPS "$cqfd_user_home" || die "chown command failed."

--- a/cqfd
+++ b/cqfd
@@ -26,6 +26,7 @@ cqfdrc=".cqfdrc"
 cqfd_user='builder'
 cqfd_user_home='/home/builder'
 cqfd_user_cwd="$cqfd_user_home/src"
+cqfd_shell=${CQFD_SHELL:-/bin/bash}
 
 ## usage() - print usage on stdout
 usage() {
@@ -376,7 +377,7 @@ test_su_session_command && has_su_session_command=1
 
 # Add the host's user and group to the container, and adjust ownership.
 groupadd -og $GROUPS -f builders || die "groupadd command failed."
-useradd -s ${CQFD_SHELL:-/bin/sh} -oN -u $UID -g $GROUPS -d "$cqfd_user_home" $cqfd_user \
+useradd -s $cqfd_shell -oN -u $UID -g $GROUPS -d "$cqfd_user_home" $cqfd_user \
 	|| die "useradd command failed."
 mkdir -p "$cqfd_user_home" || die "mkdir command failed."
 chown $UID:$GROUPS "$cqfd_user_home" || die "chown command failed."
@@ -576,7 +577,7 @@ while [ $# -gt 0 ]; do
 	shell)
 		shift
 		config_load "$flavor"
-		command_string="${CQFD_SHELL:-/bin/sh}"
+		command_string="$cqfd_shell"
 		if [ "$#" -gt 0 ]; then
 			command_string+=" ${@@Q}"
 		fi


### PR DESCRIPTION
The user `~/.ssh` config forwarding is now controlled by the `CQFD_NO_USER_SSH_CONFIG` environment variable. This allows finer control over the ssh configuration forwarding.