### PR TITLE
release: add %Du option for unix timestamp in archive name

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ following template marks:
 * ``%Gh`` - git short hash of last commit
 * ``%GH`` - git long hash of last commit
 * ``%D3`` - RFC3339 date (YYYY-MM-DD)
+* ``%Du`` - Unix timestamp
 * ``%Cf`` - current cqfd flavor name (if any)
 * ``%Po`` - value of the ``project.org`` configuration key
 * ``%Pn`` - value of the ``project.name`` configuration key

--- a/cqfd
+++ b/cqfd
@@ -299,6 +299,7 @@ make_archive() {
 	local git_short=$(git rev-parse --short HEAD 2>/dev/null)
 	local git_long=$(git rev-parse HEAD 2>/dev/null)
 	local date_rfc3339=$(date +"%Y-%m-%d")
+	local date_unix=$(date +%s)
 
 	# default name for the archive if not set
 	if [ -z "$release_archive" ]; then
@@ -310,6 +311,7 @@ make_archive() {
 			s!%Gh!'$git_short'!g;
 			s!%GH!'$git_long'!g;
 			s!%D3!'$date_rfc3339'!g;
+			s!%Du!'$date_unix'!g;
 			s!%Po!'$project_org'!g;
 			s!%Pn!'$project_name'!g;
 			s!%Cf!'$flavor'!g;')


### PR DESCRIPTION
This patch adds a new option to the archive name template: %Du. It expands to the current Unix timestamp.