### PR TITLE
tests: fix typo

### DIFF
--- a/tests/05-cqfd_run_command
+++ b/tests/05-cqfd_run_command
@@ -12,7 +12,7 @@ cd $TDIR/
 for i in 0 1; do
 	# Data set shall produce $test_file:
 
-	jtest_log info "run cqfd hout additional argument, pass $i"
+	jtest_log info "run cqfd with additional argument, pass $i"
 
 	if [ -f "$test_file" ]; then
 		jtest_log fatal "$test_file already present before test"


### PR DESCRIPTION
I guess the word with makes more sense here, since it tests the run command with arguments.