### PR TITLE
Fix "bash-completion: improve compatibility with zsh"

### DIFF
--- a/bash-completion
+++ b/bash-completion
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (C) 2017-2024 Savoir-faire Linux, Inc.
+# Copyright (C) 2017-2025 Savoir-faire Linux, Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,8 +17,10 @@
 
 if [ -z "$BASH_VERSION" ]; then
 	_init_completion() {
+		:
 	}
 	_get_first_arg() {
+		:
 	}
 fi
 


### PR DESCRIPTION
This fixes commit 14dba6973935dcdf34e787aa6c594ba12274c5bf.

The shell grammar of the well-known shells (i.e. bash, dash, ash, ksh) does not allow empty functions; however, zsh does.

This adds the null command to fix a violation of the shell grammar.

Fixes:

	source /usr/share/bash-completion/completions/cqfd
	/usr/share/bash-completion/completions/cqfd: line 20: syntax error near unexpected token `}'
	/usr/share/bash-completion/completions/cqfd: line 20: `	}'