### PR TITLE
doc: use cqfd shell as interpreter or shell in binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,37 @@ Example:
     fred@host:~/project$ cqfd shell
     fred@container:~/project$
 
+### Use cqfd as an interpreter for shell script ###
+
+You can use the `shell` command to write a shell script and run it in your
+defined container.
+
+Example:
+
+    fred@host:~/project$ cat get-container-pretty-name.sh 
+    #!/usr/bin/env -S cqfd shell
+    if ! test -e /.dockerenv; then
+        exit 1
+    fi
+    source /etc/os-release
+    echo "$PRETTY_NAME"
+    fred@host:~/projet$ ./get-container-pretty-name.sh 
+    Debian GNU/Linux 12 (bookworm)
+
+### Use cqfd as a standard shell for binaries ###
+
+You can even use the `shell` command to use it as a standard `$SHELL` so
+binaries honoring that variable run shell commands in your defined container.
+
+Example:
+
+    fred@host:~/project$ make SHELL="cqfd shell"
+    Available make targets:
+       help:      This help message
+       install:   Install script, doc and resources
+       uninstall: Remove script, doc and resources
+       tests:     Run functional tests
+
 ### Other command-line options ###
 
 In some conditions you may want to use alternate cqfd filenames and / or an

--- a/tests/08-cqfd_shell
+++ b/tests/08-cqfd_shell
@@ -74,3 +74,19 @@ if $cqfd zsh 2>&1 <<<'printf "$0"' \
 else
 	jtest_result fail
 fi
+
+jtest_prepare "cqfd shell is usable as a shell interpreter script"
+if ./whereami.sh 2>&1 | grep '^Ubuntu .* LTS$'; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
+if command -v make 2>/dev/null; then
+	jtest_prepare "cqfd shell is usable as a shell interpreter in binaries"
+	if make whereami 2>&1 | grep '^Ubuntu .* LTS$'; then
+		jtest_result pass
+	else
+		jtest_result fail
+	fi
+fi

--- a/tests/test_data/Makefile
+++ b/tests/test_data/Makefile
@@ -1,8 +1,10 @@
-.PHONY: all clean build
+.PHONY: all whereami clean build
 
 all:
 	@echo "make foo or bar!"
 
+whereami:
+	@./whereami.sh
 
 foo:
 	@echo making foo

--- a/tests/test_data/whereami.sh
+++ b/tests/test_data/whereami.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env -S cqfd shell
+if ! test -e /.dockerenv; then
+	exit 1
+fi
+source /etc/os-release
+echo "$PRETTY_NAME"


### PR DESCRIPTION
The good point in having a shell CLI is to be able to run shell scripts, either directly as a interpreter or indirectly via other binaries.

This documents all of this in the README.md.