### PR TITLE
Use variable bash compat instead of shopts

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -72,11 +72,13 @@ EOF
 # arg$1: path to ini file
 parse_ini_config_file() {
 	# bash 4.3 and later break compatibility
-	local is_compatibility_mode=false
-	if [ "${BASH_VERSINFO[0]}" -ge 4 ] && [ "${BASH_VERSINFO[1]}" -gt 2 ]; then
-		is_compatibility_mode=true
-		shopt -s compat42
-	fi
+	#
+	# in posix mode, single quotes are considered special when expanding
+	# the word portion of a double-quoted ${…} parameter expansion and can
+	# be used to quote a closing brace or other special character (this is
+	# part of POSIX interpretation 221); in later versions, single quotes
+	# are not special within double-quoted word expansions
+	local BASH_COMPAT=42
 
 	if [ ! -f "$1" ]; then
 		die "Unable to find $1 - create it or pick one using 'cqfd -f'"
@@ -101,11 +103,6 @@ parse_ini_config_file() {
 	ini[${#ini[*]} + 1]='}'                           # add the last brace
 	if ! eval "$(echo "${ini[*]}")" 2>/dev/null; then # eval the result
 		die "$1: Invalid ini-file!"
-	fi
-
-	# restore previous bash behaviour
-	if $is_compatibility_mode; then
-		shopt -u compat42
 	fi
 }
 

--- a/cqfd
+++ b/cqfd
@@ -73,7 +73,7 @@ EOF
 parse_ini_config_file() {
 	# bash 4.3 and later break compatibility
 	local is_compatibility_mode=false
-	if [ $BASH_VERSINFO -ge 4 -a ${BASH_VERSINFO[1]} -gt 2 ]; then
+	if [ "${BASH_VERSINFO[0]}" -ge 4 ] && [ "${BASH_VERSINFO[1]}" -gt 2 ]; then
 		is_compatibility_mode=true
 		shopt -s compat42
 	fi


### PR DESCRIPTION
TL;DR; This simplifies the bash compatibility hack for ini parsing by
setting the variable BASH_COMPAT locally to the function. It adds the
comment making explicit the compatibility requirement.

bash(1) evolves through the versions and it maintains compatibility
modes.

The function parse_ini_config_file() fails if shopts compat42[1] is
unset:

	./support/cqfd: eval: line 120: syntax error near unexpected token `)'

According to bash documentation[2]:

	compat42

	- the replacement string in double-quoted pattern substitution
	  does not undergo quote removal, as it does in versions after
	  bash-4.2

	- in posix mode, single quotes are considered special when
	  expanding the word portion of a double-quoted ${…} parameter
	  expansion and can be used to quote a closing brace or other
	  special character (this is part of POSIX interpretation 221);
	  in later versions, single quotes are not special within
	  double-quoted word expansions

Obviously, one of these two compatibility is required to perform the
parameter expansions[3] below:

	ini=( ${ini[*]/#\\[/\}$'\n'cfg.section.} ) # set section prefix

The shopt builtin options are mutually exclusives; therefore, it is
tricky to restore the previous option if one is set.

Luckily:

	Bash-4.3 introduced a new shell variable: BASH_COMPAT. The value
	assigned to this variable (a decimal version number like 4.2, or
	an integer corresponding to the compatNN option, like 42)
	determines the compatibility level.

	Starting with bash-4.4, Bash has begun deprecating older
	compatibility levels. Eventually, the options will be removed in
	favor of BASH_COMPAT.

	Bash-5.0 is the final version for which there will be an
	individual shopt option for the previous version. Users should
	use BASH_COMPAT on bash-5.0 and later versions.

The variable BASH_COMPAT[4] was introduced since 4.3, the same version
that has introduced the breaking change required to run cfg_parser().
That variable is the way of setting to compatibility since then; there
is no more shopt option since 5.0.

This removes the call to shopts and adds the local variable BASH_COMPAT
to the function cfg_parser() so the previous value is automatically
"restored" once the function exits.

[1]: https://ajdiaz.wordpress.com/2008/02/09/bash-ini-parser/#comment-1187
[2]: https://www.gnu.org/software/bash/manual/html_node/Shell-Compatibility-Mode.html
[3]: https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html
[4]: https://www.gnu.org/software/bash/manual/html_node/Bash-Variables.html#index-BASH_005fENV