### PR TITLE
cqfd: restore IFS after call to parse_ini_config_file()

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -79,6 +79,7 @@ parse_ini_config_file() {
 	# part of POSIX interpretation 221); in later versions, single quotes
 	# are not special within double-quoted word expansions
 	local BASH_COMPAT=42
+	local IFS
 
 	if [ ! -f "$1" ]; then
 		die "Unable to find $1 - create it or pick one using 'cqfd -f'"
@@ -453,7 +454,7 @@ config_load() {
 		local cqfdrc_dir="$cqfd_project_dir/"
 	fi
 
-	IFS="$IFS" parse_ini_config_file "${cqfdrc_dir}${cqfdrc}"
+	parse_ini_config_file "${cqfdrc_dir}${cqfdrc}"
 
 	# generate dynamically the list of flavors based on the names of shell
 	# functions reported by the buildtin:


### PR DESCRIPTION
The function parse_ini_config_file() modifies (i.e. sets) the variable IFS[1] and does not restore it.

As a consequence, the function modifies the word splitting[2] for the entire script after it is called. The "words" are split by lines and "breaks" the default word splitting by whitespaces.

This makes the variable IFS local to the function so the previous value is automatically "restored" once the function exits.

[1]: https://www.gnu.org/software/bash/manual/bash.html#index-IFS
[2]: https://www.gnu.org/software/bash/manual/html_node/Word-Splitting.html