### PR TITLE
Makefile: tests: set GIT_DIR

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -18,4 +18,4 @@ jobs:
       run: make check
 
     - name: Run tests
-      run: make tests
+      run: make tests GIT_CONFIG_GLOBAL=/dev/null

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ user-%:
 	$(MAKE) $* PREFIX=$$HOME/.local
 
 test tests:
-	@$(MAKE) -C tests
+	@$(MAKE) -C tests GIT_DIR=$(CURDIR)/.git
 
 check:
 	shellcheck cqfd

--- a/cqfd
+++ b/cqfd
@@ -342,10 +342,10 @@ make_archive() {
 	done
 
 	# template the generated archive's filename
-	git_short=$(git rev-parse --short HEAD 2>/dev/null || true)
-	git_long=$(git rev-parse HEAD 2>/dev/null || true)
-	date_rfc3339=$(date +%Y-%m-%d || true)
-	date_unix=$(date +%s || true)
+	git_short=$(git rev-parse --short HEAD 2>/dev/null || echo unset)
+	git_long=$(git rev-parse HEAD 2>/dev/null || echo unset)
+	date_rfc3339=$(date +"%Y-%m-%d")
+	date_unix=$(date +%s)
 
 	# default name for the archive if not set
 	if [ -z "$release_archive" ]; then

--- a/tests/06-cqfd_release
+++ b/tests/06-cqfd_release
@@ -125,10 +125,7 @@ export CTEST=foobar
 d3=$(date --rfc-3339='date')
 echo 'archive=cqfd-%D3-$CTEST.tar.xz' >> .cqfdrc
 
-# Generate the release archive
-$cqfd release
-
-if tar tf cqfd-$d3-foobar.tar.xz >/dev/null 2>&1; then
+if $cqfd release && tar tf cqfd-$d3-foobar.tar.xz >/dev/null 2>&1; then
 	jtest_result pass
 else
 	jtest_result fail

--- a/tests/06-cqfd_release
+++ b/tests/06-cqfd_release
@@ -119,7 +119,7 @@ rm -rf "${tmp_dir}"
 ################################################################################
 # Now test adding an archive filename template to the config
 ################################################################################
-jtest_prepare "build.archive can template filenames"
+jtest_prepare "build.archive can template filenames (RFC3339 date)"
 
 export CTEST=foobar
 d3=$(date --rfc-3339='date')
@@ -131,6 +131,91 @@ else
 	jtest_result fail
 fi
 rm -f cqfd-$d3-foobar.tar.xz
+
+jtest_prepare "build.archive can template filenames (git short hash of last commit)"
+sed -i -e '$ s!^archive=.*!archive=cqfd-%Gh-$CTEST.tar.xz!' .cqfdrc
+
+if $cqfd release &&
+   ls -1 cqfd-*-foobar.tar.xz | grep -q "^cqfd-[[:xdigit:]]\{4,40\}-foobar.tar.xz$" &&
+   tar tf cqfd-*-foobar.tar.xz >/dev/null 2>&1; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+rm -f cqfd-*-foobar.tar.xz
+
+jtest_prepare "build.archive can template filenames (git long hash of last commit)"
+sed -i -e '$ s!^archive=.*!archive=cqfd-%GH-$CTEST.tar.xz!' .cqfdrc
+
+if $cqfd release &&
+   ls -1 cqfd-*-foobar.tar.xz | grep -q "^cqfd-[[:xdigit:]]\{40\}-foobar.tar.xz$" &&
+   tar tf cqfd-*-foobar.tar.xz >/dev/null 2>&1; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+rm -f cqfd-*-foobar.tar.xz
+
+jtest_prepare "build.archive can template filenames (Unix timestamp)"
+sed -i -e '$ s!^archive=.*!archive=cqfd-%Du-$CTEST.tar.xz!' .cqfdrc
+
+if $cqfd release &&
+   ls -1 cqfd-*-foobar.tar.xz | grep -q "^cqfd-[[:digit:]]\{1,20\}-foobar.tar.xz$" &&
+   tar tf cqfd-*-foobar.tar.xz >/dev/null 2>&1; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+rm -f cqfd-*-foobar.tar.xz
+
+jtest_prepare "build.archive can template filenames (current cqfd flavor name unset)"
+sed -i -e '$ s!^archive=.*!archive=cqfd-%Cf-$CTEST.tar.xz!' .cqfdrc
+
+if $cqfd release && tar tf cqfd--foobar.tar.xz >/dev/null 2>&1; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+rm -f cqfd--foobar.tar.xz
+
+jtest_prepare "build.archive can template filenames (current cqfd flavor name set)"
+
+if $cqfd -b foo release && tar tf cqfd-foo.tar.xz >/dev/null 2>&1; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+rm -f cqfd-foo.tar.xz
+
+jtest_prepare "build.archive can template filenames (value of the project.org configuration key)"
+sed -i -e '$ s!^archive=.*!archive=cqfd-%Po-$CTEST.tar.xz!' .cqfdrc
+
+if $cqfd release && tar tf cqfd-cqfd-foobar.tar.xz >/dev/null 2>&1; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+rm -f cqfd-cqfd-foobar.tar.xz
+
+jtest_prepare "build.archive can template filenames (value of the project.name configuration key)"
+sed -i -e '$ s!^archive=.*!archive=cqfd-%Pn-$CTEST.tar.xz!' .cqfdrc
+
+if $cqfd release && tar tf cqfd-test-foobar.tar.xz >/dev/null 2>&1; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+rm -f cqfd-test-foobar.tar.xz
+
+jtest_prepare "build.archive can template filenames (litteral '%' sign)"
+sed -i -e '$ s!^archive=.*!archive=cqfd-%%-$CTEST.tar.xz!' .cqfdrc
+
+if $cqfd release && tar tf cqfd-%-foobar.tar.xz >/dev/null 2>&1; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+rm -f cqfd-%-foobar.tar.xz
 
 ################################################################################
 # Now test generation of .tar.gz archives


### PR DESCRIPTION
The git-log commands run to replace the git templates (short or long hash of the last commmit) fail during the tests, as the test cd to another directory, and thus left the git repository.

The error fails silently and it does not break the execution of cqfd because the local declaration and the assignment are both performed simultaneously, masking the returned value. See shellcheck errors below:

	In cqfd line 301:
		local git_short=$(git rev-parse --short HEAD 2>/dev/null)
	              ^-------^ SC2155 (warning): Declare and assign separately to avoid masking return values.

	In cqfd line 302:
		local git_long=$(git rev-parse HEAD 2>/dev/null)
	              ^------^ SC2155 (warning): Declare and assign separately to avoid masking return values.

	In cqfd line 303:
		local date_rfc3339=$(date +"%Y-%m-%d")
	              ^----------^ SC2155 (warning): Declare and assign separately to avoid masking return values.

	In cqfd line 304:
		local date_unix=$(date +%s)
	              ^-------^ SC2155 (warning): Declare and assign separately to avoid masking return values.

This sets the GIT_DIR to ensure the git-log commands run by cqfd release succeeds during the tests. So one can implement the tests using the git-log templates.

See git(1):

	OPTIONS

	--git-dir=<path>

	Set the path to the repository (".git" directory). This can also
	be controlled by setting the GIT_DIR environment variable. It
	can be an absolute path or relative path to current working
	directory.

	Specifying the location of the ".git" directory using this
	option (or GIT_DIR environment variable) turns off the
	repository discovery that tries to find a directory with ".git"
	subdirectory (which is how the repository and the top-level of
	the working tree are discovered), and tells Git that you are at
	the top level of the working tree. If you are not at the
	top-level directory of the working tree, you should tell Git
	where the top-level of the working tree is, with the
	--work-tree=<path> option (or GIT_WORK_TREE environment
	variable)

	If you just want to run git as if it was started in <path> then
	use git -C <path>.

	ENVIRONMENT VARIABLES

	GIT_DIR

	If the GIT_DIR environment variable is set then it specifies a
	path to use instead of the default .git for the base of the
	repository. The --git-dir command-line option also sets this
	value.

Fixes:

	diff --git a/cqfd b/cqfd
	--- a/cqfd
	+++ b/cqfd
	@@ -298,10 +298,10 @@ make_archive() {
	        done

	        # template the generated archive's filename
	-       local git_short=$(git rev-parse --short HEAD 2>/dev/null)
	-       local git_long=$(git rev-parse HEAD 2>/dev/null)
	-       local date_rfc3339=$(date +"%Y-%m-%d")
	-       local date_unix=$(date +%s)
	+       git_short=$(git rev-parse --short HEAD 2>/dev/null)
	+       git_long=$(git rev-parse HEAD 2>/dev/null)
	+       date_rfc3339=$(date +"%Y-%m-%d")
	+       date_unix=$(date +%s)

	        # default name for the archive if not set
	        if [ -z "$release_archive" ]; then

	[22:58:34|info] -----------------------------------------------------
	[22:58:34|info] started from ./06-cqfd_release in /tmp/tmp.iTL5Rn2FsD
	[22:58:34|notice] preparing "cqfd release fails without files parameter"
	cqfd: fatal: No files to archive, check files in .cqfdrc
	[22:58:35|info] result: cqfd release fails without files parameter: PASS
	[22:58:35|notice] preparing "cqfd release now with a files parameter"
	[22:58:37|info] result: cqfd release now with a files parameter: FAIL
	[22:58:37|notice] preparing "default orgname-project.tar.xz archive is generated"
	[22:58:37|info] result: default orgname-project.tar.xz archive is generated: FAIL
	[22:58:37|notice] preparing "archived files NOT at root of tar archive"
	tar: cqfd-test.tar.xz: Cannot open: No such file or directory
	tar: Error is not recoverable: exiting now
	tar: cqfd-test.tar.xz: Cannot open: No such file or directory
	tar: Error is not recoverable: exiting now
	tar: cqfd-test.tar.xz: Cannot open: No such file or directory
	tar: Error is not recoverable: exiting now
	[22:58:37|info] result: archived files NOT at root of tar archive: FAIL
	[22:58:37|notice] preparing "archived files NOT at root of tar archive if tar_transform=no"
	[22:58:38|error] error triggered by ./06-cqfd_release
	tar: cqfd-test.tar.xz: Cannot open: No such file or directory
	tar: Error is not recoverable: exiting now
	tar: cqfd-test.tar.xz: Cannot open: No such file or directory
	tar: Error is not recoverable: exiting now
	tar: cqfd-test.tar.xz: Cannot open: No such file or directory
	tar: Error is not recoverable: exiting now
	[22:58:38|info] result: archived files NOT at root of tar archive if tar_transform=no: FAIL
	[22:58:38|notice] preparing "archived files at root of tar archive if tar_transform=yes"
	[22:58:40|error] error triggered by ./06-cqfd_release
	tar: cqfd-test.tar.xz: Cannot open: No such file or directory
	tar: Error is not recoverable: exiting now
	tar: cqfd-test.tar.xz: Cannot open: No such file or directory
	tar: Error is not recoverable: exiting now
	tar: cqfd-test.tar.xz: Cannot open: No such file or directory
	tar: Error is not recoverable: exiting now
	[22:58:40|info] result: archived files at root of tar archive if tar_transform=yes: FAIL
	[22:58:40|notice] preparing "symlink files are copied in the tar archive"
	[22:58:43|error] error triggered by ./06-cqfd_release
	tar: cqfd-test.tar.xz: Cannot open: No such file or directory
	tar: Error is not recoverable: exiting now
	diff: /tmp/tmp.scEI0uhoUm/a/cqfd_a.txt: No such file or directory
	diff: /tmp/tmp.scEI0uhoUm/link.txt: No such file or directory
	[22:58:43|info] result: symlink files are copied in the tar archive: FAIL
	[22:58:45|notice] preparing "build.archive can template filenames"
	[22:58:46|error] error triggered by ./06-cqfd_release
	[22:58:46|info] result: build.archive can template filenames: FAIL
	[22:58:46|notice] preparing "build.archive can make a .tar.gz archive"
	[22:58:48|error] error triggered by ./06-cqfd_release
	[22:58:48|info] result: build.archive can make a .tar.gz archive: FAIL
	[22:58:48|notice] preparing "build.archive can make a .zip archive"
	[22:58:49|error] error triggered by ./06-cqfd_release
	[22:58:49|info] result: build.archive can make a .zip archive: FAIL
	[22:58:49|notice] preparing "release for flavor foo creates cqfd-foo.tar.xz"
	making foo
	[22:58:51|error] error triggered by ./06-cqfd_release
	[22:58:51|info] result: release for flavor foo creates cqfd-foo.tar.xz: FAIL
	[22:58:51|notice] preparing "release for flavor bar creates cqfd-bar.tar.xz"
	making bar
	[22:58:53|error] error triggered by ./06-cqfd_release
	[22:58:53|info] result: release for flavor bar creates cqfd-bar.tar.xz: FAIL
	[22:58:53|notice] preparing "cqfd fails on missing file in build.files"
	cqfd: fatal: Unable to release: unable to find ThisFileDoesNotExist.txt
	[22:58:54|info] result: cqfd fails on missing file in build.files: PASS
	[22:58:54|notice] preparing "cqfd resolves globs in build.files"
	[22:58:56|info] result: cqfd resolves globs in build.files: FAIL
	[22:58:56|notice] preparing "resolved globs are properly archived"
	tar: cqfd-foobar.tar.xz: Cannot open: No such file or directory
	tar: Error is not recoverable: exiting now
	[22:58:56|error] error triggered by ./06-cqfd_release
	[22:58:56|info] result: resolved globs are properly archived: FAIL
	[22:58:56|error] returning error as ./06-cqfd_release produced errors
	(...)
	  |PASS|cqfd release fails without files parameter
	**|FAIL|cqfd release now with a files parameter
	**|FAIL|default orgname-project.tar.xz archive is generated
	**|FAIL|archived files NOT at root of tar archive
	**|FAIL|archived files NOT at root of tar archive if tar_transform=no
	**|FAIL|archived files at root of tar archive if tar_transform=yes
	**|FAIL|symlink files are copied in the tar archive
	**|FAIL|build.archive can template filenames
	**|FAIL|build.archive can make a .tar.gz archive
	**|FAIL|build.archive can make a .zip archive
	**|FAIL|release for flavor foo creates cqfd-foo.tar.xz
	**|FAIL|release for flavor bar creates cqfd-bar.tar.xz
	  |PASS|cqfd fails on missing file in build.files
	**|FAIL|cqfd resolves globs in build.files
	**|FAIL|resolved globs are properly archived