### PR TITLE
tests: 08-cqfd_shell: use cqfd from TDIR

### DIFF
--- a/tests/08-cqfd_shell
+++ b/tests/08-cqfd_shell
@@ -76,7 +76,7 @@ else
 fi
 
 jtest_prepare "cqfd shell is usable as a shell interpreter script"
-if ./whereami.sh 2>&1 | grep '^Ubuntu .* LTS$'; then
+if PATH="$TDIR/.cqfd:$PATH"; ./whereami.sh 2>&1 | grep '^Ubuntu .* LTS$'; then
 	jtest_result pass
 else
 	jtest_result fail
@@ -84,7 +84,7 @@ fi
 
 if command -v make 2>/dev/null; then
 	jtest_prepare "cqfd shell is usable as a shell interpreter in binaries"
-	if make whereami 2>&1 | grep '^Ubuntu .* LTS$'; then
+	if PATH="$TDIR/.cqfd:$PATH"; make whereami 2>&1 | grep '^Ubuntu .* LTS$'; then
 		jtest_result pass
 	else
 		jtest_result fail


### PR DESCRIPTION
This ensures to use cqfd installed in the TDIR instead of the one installed in host system.

Fixes (if cqfd is not available in PATH):

	$ make test
	(...)
	[10:48:06|notice] preparing "cqfd shell is usable as a shell interpreter script"
	[10:48:06|info] result: cqfd shell is usable as a shell interpreter script: FAIL
	/usr/bin/make
	[10:48:06|notice] preparing "cqfd shell is usable as a shell interpreter in binaries"
	[10:48:06|info] result: cqfd shell is usable as a shell interpreter in binaries: FAIL
	(...)
	**|FAIL|cqfd shell is usable as a shell interpreter script
	**|FAIL|cqfd shell is usable as a shell interpreter in binaries
	(...)
	 --------------------
	make[1]: Leaving directory '/home/gportay/src/cqfd/tests'