### PR TITLE
ci: make failing tests fail the CI

### DIFF
--- a/tests/05-cqfd_run_extra_groups
+++ b/tests/05-cqfd_run_extra_groups
@@ -2,40 +2,44 @@
 
 . "$(dirname $0)"/jtest.inc "$1"
 
+cqfd="$TDIR/.cqfd/cqfd"
+
+cd $TDIR/
+
+cqfdrc_old=$(mktemp)
+cp -f .cqfdrc "$cqfdrc_old"
+
+################################################################################
+# 'cqfd run' should add extra_groups provided by an environment variable
+################################################################################
+jtest_prepare "'cqfd run' should add extra_groups provided by an env variable"
+result=$(user_extra_groups="docker newgroup:12345" $cqfd run 'groups' | grep docker | grep newgroup)
+
 if [ "$USER" != "runner" ]; then
-	cqfd="$TDIR/.cqfd/cqfd"
-
-	cd $TDIR/
-
-	cqfdrc_old=$(mktemp)
-	cp -f .cqfdrc "$cqfdrc_old"
-
-	################################################################################
-	# 'cqfd run' should add extra_groups provided by an environment variable
-	################################################################################
-	jtest_prepare "'cqfd run' should add extra_groups provided by an env variable"
-	result=$(user_extra_groups="docker newgroup:12345" $cqfd run 'groups' | grep docker | grep newgroup)
-
 	if [ -n "$result" ]; then
 		jtest_result pass
 	else
 		jtest_result fail
 	fi
-
-	################################################################################
-	# 'cqfd run' should add extra_groups provided by the config
-	################################################################################
-	jtest_prepare "'cqfd run' should add config's extra_groups to the local user"
-	echo 'user_extra_groups="docker newgroup:12345"' >> .cqfdrc
-	result=$($cqfd run 'groups' | grep docker | grep newgroup)
-
-	if [ -n "$result" ]; then
-		jtest_result pass
-	else
-		jtest_result fail
-	fi
-
-	mv -f "$cqfdrc_old" .cqfdrc
 else
-	jtest_log notice "Skip 05-cqfd_run_extra_groups tests on GitHub CI"
+	jtest_result skip
 fi
+
+################################################################################
+# 'cqfd run' should add extra_groups provided by the config
+################################################################################
+jtest_prepare "'cqfd run' should add config's extra_groups to the local user"
+echo 'user_extra_groups="docker newgroup:12345"' >> .cqfdrc
+result=$($cqfd run 'groups' | grep docker | grep newgroup)
+
+if [ "$USER" != "runner" ]; then
+	if [ -n "$result" ]; then
+		jtest_result pass
+	else
+		jtest_result fail
+	fi
+else
+	jtest_result skip
+fi
+
+mv -f "$cqfdrc_old" .cqfdrc

--- a/tests/09-cqfd-pts
+++ b/tests/09-cqfd-pts
@@ -13,10 +13,14 @@ sed -i -e "/\[build\]/,/^$/s/^command=.*$/command='tty || true'/" .cqfdrc
 $cqfd init
 
 jtest_prepare "cqfd without redirection should allocate a tty"
-if $cqfd | grep "/dev/pts/1" ; then
-	jtest_result pass
+if tty; then
+	if $cqfd | grep "/dev/pts/1" ; then
+		jtest_result pass
+	else
+		jtest_result fail
+	fi
 else
-	jtest_result fail
+	jtest_result skip
 fi
 
 jtest_prepare "cqfd with stdin redirected to /dev/null should not allocate a pty"

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -4,13 +4,17 @@ tests:
 	@$(eval TDIR=$(shell mktemp -d))
 	@for f in [0-9][0-9]*; do \
 		if [ -x "$$f" ]; then \
-			./$$f $(TDIR) || failed=1; \
+			./$$f $(TDIR); \
 		fi; \
 	done; \
+	failed=0; \
 	if [ -f $(TDIR)/.jtest_results ]; then \
 		echo " --- Test results ---"; \
 		cat "$(TDIR)"/.jtest_results; \
 		echo " --------------------"; \
+		if grep -q "FAIL" "$(TDIR)"/.jtest_results; then \
+			failed=1; \
+		fi; \
 	fi; \
 	if echo $(TDIR) | grep -q "/tmp/tmp\.[a-zA-Z]"; then \
 		rm -rf $(TDIR); \

--- a/tests/jtest.inc
+++ b/tests/jtest.inc
@@ -6,6 +6,49 @@
 TDIR="$1"
 JTEST_LOGLVL=debug # all debug error fatal info off
 
+# _colorize: return colorized string
+# arg1: color name
+# arg2..: string
+_colorize()
+{
+	local color="$1"; shift
+	local text="$*"
+	local nc='\033[0m'
+	local c
+
+	if [ -n "$NO_COLOR" ]; then
+		printf "%s" "$text"
+		return
+	fi
+
+	# Only colorize a few terminal types
+	# "dumb" is the terminal type in GitHub Actions
+	case "$TERM" in
+	linux*|xterm*|screen*|tmux*|vt102|dumb) ;;
+	*) printf "%s" "$text"; return ;;
+	esac
+
+	case "$color" in
+	gray)   c='\033[1;30m' ;;
+	red)    c='\033[1;31m' ;;
+	green)  c='\033[1;32m' ;;
+	yellow) c='\033[1;33m' ;;
+	blue)   c='\033[1;34m' ;;
+	purple) c='\033[1;35m' ;;
+	cyan)   c='\033[1;36m' ;;
+
+	red2)    c='\033[1;91m' ;;
+	green2)  c='\033[1;92m' ;;
+	yellow2) c='\033[1;93m' ;;
+	blue2)   c='\033[1;94m' ;;
+	purple2) c='\033[1;95m' ;;
+	cyan2)   c='\033[1;96m' ;;
+	white2)  c='\033[1;97m' ;;
+	esac
+
+	printf "${c}${text}${nc}"
+}
+
 # _jtest_log_init() - initialize log subsystem
 declare -A _jloglevels
 _jtest_log_init()
@@ -95,12 +138,17 @@ jtest_result()
 
 	if [ "$status" = "fail" ]; then
 		pfx="**"
+	elif [ "$status" = "skip" ]; then
+		pfx="--"
 	fi
 
 	echo "$pfx|${status^^}|$_jtest_current" >>$TDIR/.jtest_results
 
-	[ "$status" = "pass" ] && status="\e[32mPASS"
-	[ "$status" = "fail" ] && status="\e[31mFAIL"
+	case "$status" in
+		pass) status=$(_colorize green "PASS") ;;
+		fail) status=$(_colorize red "FAIL") ;;
+		skip) status=$(_colorize yellow2 "SKIP") ;;
+	esac
 
 	jtest_log info "result: $_jtest_current: $status"
 	unset _jtest_current

--- a/tests/jtest.inc
+++ b/tests/jtest.inc
@@ -87,8 +87,7 @@ jtest_prepare()
 }
 
 # jtest_result() - report test result
-# arg2: "pass" or "fail"
-# arg3"
+# arg1: "pass", "fail" or "skip"
 jtest_result()
 {
 	local status="$1"


### PR DESCRIPTION
Currently, when a test is failing, the CI does not fail because the script does not detect correctly a failure.

This commit makes the test of a failing test more explicit