### PR TITLE
cqfd: add support for the 'docker_build_args' build option

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,12 @@ inside the docker image.
 ``flavors``: the list of build flavors (see below). Each flavor has its
 own command just like `build.command`.
 
+``docker_build_args`` (optional): arguments used to invoke `docker build`.
+For example, to attempt to pull newer version of the image, it can be set like:
+```
+docker_build_args='--pull=true'
+```
+
 ``docker_run_args`` (optional): arguments used to invoke `docker run`.
 For example, to share networking with the host, it can be set like:
 ```

--- a/cqfd
+++ b/cqfd
@@ -127,6 +127,13 @@ docker_build() {
 		args+=(-q)
 	fi
 
+	# Append extra args from the .cqfdrc [build] section
+	if [ "$build_docker_build_args" ]; then
+		local array
+		read -a array <<<"$build_docker_build_args"
+		args+=("${array[@]}")
+	fi
+
 	# Append extra args from $CQFD_EXTRA_BUILD_ARGS
 	if [ "$CQFD_EXTRA_BUILD_ARGS" ]; then
 		local array
@@ -506,6 +513,7 @@ config_load() {
 	fi
 
 	build_cmd="$command"
+	build_docker_build_args="$docker_build_args"
 	build_docker_run_args="$docker_run_args"
 	cqfd_extra_groups="$user_extra_groups"
 	release_files="$files"

--- a/cqfd
+++ b/cqfd
@@ -2,7 +2,7 @@
 #
 # cqfd - a tool to wrap commands in controlled Docker containers
 #
-# Copyright (C) 2015-2024 Savoir-faire Linux, Inc.
+# Copyright (C) 2015-2025 Savoir-faire Linux, Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -121,13 +121,29 @@ debug() {
 
 # docker_build() - Initialize build container
 docker_build() {
-	if [ -z "$project_build_context" ]; then
-		debug executing: docker build ${quiet:+-q} $CQFD_EXTRA_BUILD_ARGS -t "$docker_img_name" "$(dirname "$dockerfile")"
-		docker build ${quiet:+-q} $CQFD_EXTRA_BUILD_ARGS -t "$docker_img_name" "$(dirname "$dockerfile")"
-	else
-		debug executing: docker build ${quiet:+-q} $CQFD_EXTRA_BUILD_ARGS -t "$docker_img_name" "${project_build_context}" -f "$dockerfile"
-		docker build ${quiet:+-q} $CQFD_EXTRA_BUILD_ARGS -t "$docker_img_name" "${project_build_context}" -f "$dockerfile"
+	local args=()
+
+	if [ "$quiet" ]; then
+		args+=(-q)
 	fi
+
+	# Append extra args from $CQFD_EXTRA_BUILD_ARGS
+	if [ "$CQFD_EXTRA_BUILD_ARGS" ]; then
+		local array
+		read -a array <<<"$CQFD_EXTRA_BUILD_ARGS"
+		args+=("${array[@]}")
+	fi
+
+	args+=(-t "$docker_img_name")
+
+	if [ -z "$project_build_context" ]; then
+		args+=("$(dirname "$dockerfile")")
+	else
+		args+=("$project_build_context" -f "$dockerfile")
+	fi
+
+	debug executing: docker build "${args[@]}"
+	docker build "${args[@]}"
 }
 
 # image_exists_locally(): checks if image exists in the local image store

--- a/tests/05-cqfd_init_extra_hosts
+++ b/tests/05-cqfd_init_extra_hosts
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+. "$(dirname $0)"/jtest.inc "$1"
+cqfd="$TDIR/.cqfd/cqfd"
+
+cd $TDIR/
+
+jtest_prepare "run cqfd with docker_build_args in config"
+# setup -- add the command and docker_build_args option to configs
+echo "RUN cp /etc/hosts /tmp/hosts" >> "$TDIR/.cqfd/docker/Dockerfile"
+sed '/\[build\]/adocker_build_args="--add-host testhost:1.2.3.4"'\
+    -i "$TDIR/.cqfdrc"
+output=$($cqfd init; $cqfd run cat /tmp/hosts; exit 0)
+
+if [[ "$output" == *"1.2.3.4"*"testhost"* ]]; then
+    jtest_result pass
+else
+    jtest_result fail
+fi
+
+# teardown -- clear the command and docker_build_args option from config
+sed '/\[build\]/{n;d}' -i "$TDIR/.cqfdrc"
+sed '$d' -i "$TDIR/.cqfd/docker/Dockerfile"


### PR DESCRIPTION
This enables declaring a set of arguments to use with 'docker build', as
a declarative complement to CQFD_EXTRA_BUILD_ARGS.

See https://github.com/savoirfairelinux/cqfd/commit/4c5018173fe0fc6c7dcd8a48bae57fc131138bfe.

Fixes: #153