### PR TITLE
cqfd: add CQFD_DOCKER option

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,12 @@ The following environment variables are supported by cqfd to provide
 the user with extra flexibility during his day-to-day development
 tasks:
 
+``CQFD_DOCKER``: program used to invoke `docker` client.
+For example, to use docker if not in the docker group, it can be set like:
+```
+docker='sudo docker'
+```
+
 ``CQFD_EXTRA_RUN_ARGS``: A space-separated list of additional
 docker-run options to be append to the starting container.
 Format is the same as (and passed to) docker-run’s options.

--- a/cqfd
+++ b/cqfd
@@ -29,6 +29,7 @@ cqfd_user_home='/home/builder'
 cqfd_user_cwd="$cqfd_user_home/src"
 cqfd_shell=${CQFD_SHELL:-/bin/bash}
 cqfd_docker_gid="${CQFD_DOCKER_GID:-0}"
+cqfd_docker="${CQFD_DOCKER:-docker}"
 
 ## usage() - print usage on stdout
 usage() {
@@ -146,14 +147,14 @@ docker_build() {
 		args+=("$project_build_context" -f "$dockerfile")
 	fi
 
-	debug executing: docker build "${args[@]}"
-	docker build "${args[@]}"
+	debug executing: "${cqfd_docker}" build "${args[@]}"
+	"${cqfd_docker}" build "${args[@]}"
 }
 
 # image_exists_locally(): checks if image exists in the local image store
 # arg$1: the image name to check
 image_exists_locally() {
-	docker image inspect "$1" &> /dev/null
+	"${cqfd_docker}" image inspect "$1" &> /dev/null
 }
 
 # docker_run() - run command in configured container
@@ -177,7 +178,7 @@ docker_run() {
 	if ! image_exists_locally "$docker_img_name"; then
 		# If custom image name is used, try to pull it before dying
 		if [ "$project_custom_img_name" ]; then
-			if ! docker pull "$docker_img_name" >& /dev/null; then
+			if ! "${cqfd_docker}" pull "$docker_img_name" >& /dev/null; then
 				die "Custom image couldn't be pulled, please build/upload it first"
 			fi
 		else
@@ -315,8 +316,8 @@ docker_run() {
 
 	args+=("$docker_img_name" cqfd_launch "$1")
 
-	debug executing: docker run "${args[@]}"
-	docker run "${args[@]}"
+	debug executing: "${cqfd_docker}" run "${args[@]}"
+	"${cqfd_docker}" run "${args[@]}"
 }
 
 # make_archive(): Create a release package.


### PR DESCRIPTION
This adds the environment CQFD_DOCKER to set the docker binary. It
allows to run the client using sudo(8).