### PR TITLE
tests: 08-cqfd_shell: log skipped test

### DIFF
--- a/tests/08-cqfd_shell
+++ b/tests/08-cqfd_shell
@@ -82,11 +82,13 @@ else
 	jtest_result fail
 fi
 
+jtest_prepare "cqfd shell is usable as a shell interpreter in binaries"
 if command -v make 2>/dev/null; then
-	jtest_prepare "cqfd shell is usable as a shell interpreter in binaries"
 	if PATH="$TDIR/.cqfd:$PATH"; make whereami 2>&1 | grep '^Ubuntu .* LTS$'; then
 		jtest_result pass
 	else
 		jtest_result fail
 	fi
+else
+	jtest_result skip
 fi


### PR DESCRIPTION
The commit 41732153f5e61b4c12413a3c6a103501b2a99140 has introduced the skip result.

This logs the skipped test if make is not installed.