### PR TITLE
tests: add testing for docker-out-of-docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,12 @@ the user's ``~/.ssh`` configuration to the container.
 ``CQFD_NO_USER_GIT_CONFIG``: Set to ``true`` to disable forwarding
 the user's ``~/.gitconfig`` configuration to the container.
 
+``CQFD_BIND_DOCKER_SOCK``: Set to ``true`` to enable forwarding the
+docker socket to the container.
+
+``CQFD_DOCKER_GID``: The gid of the docker group in host to map to
+the cqfd group in the container.
+
 ``CQFD_SHELL``: The shell to be launched, by default ``/bin/sh``.
 
 ### Appending to the build command ###

--- a/cqfd
+++ b/cqfd
@@ -28,6 +28,7 @@ cqfd_user='builder'
 cqfd_user_home='/home/builder'
 cqfd_user_cwd="$cqfd_user_home/src"
 cqfd_shell=${CQFD_SHELL:-/bin/bash}
+cqfd_docker_gid="${CQFD_DOCKER_GID:-0}"
 
 ## usage() - print usage on stdout
 usage() {
@@ -59,7 +60,7 @@ Commands:
 Command options for run / release:
     -c <args>            Append args to the default command string.
 
-    cqfd is Copyright (C) 2015-2024 Savoir-faire Linux, Inc.
+    cqfd is Copyright (C) 2015-2025 Savoir-faire Linux, Inc.
 
     This program comes with ABSOLUTELY NO WARRANTY. This is free
     software, and you are welcome to redistribute it under the terms
@@ -220,6 +221,21 @@ docker_run() {
 		cqfd_user_cwd="$(pwd)"
 	fi
 
+	# Get the docker gid if the group exists
+	if [ "$cqfd_docker_gid" -eq 0 ]; then
+		local docker_group
+		if IFS=: read -r -a docker_group < <(getent group docker); then
+			local docker_users
+			IFS=, read -r -a docker_users <<<"${docker_group[3]}"
+			for user in "${docker_users[@]}"; do
+				if [ "$user" = "$cqfd_user" ]; then
+					cqfd_docker_gid="${docker_group[2]}"
+					break
+				fi
+			done
+		fi
+	fi
+
 	# Display a warning message if using no more supported options
 	if [ -n "$CQFD_EXTRA_VOLUMES" ]; then
 		die 'Warning: CQFD_EXTRA_VOLUMES is no more supported, use
@@ -282,6 +298,10 @@ docker_run() {
 
 	if [ "$CQFD_NO_USER_GIT_CONFIG" != true ] && [ -f "$cqfd_user_home/.gitconfig" ]; then
 		args+=(--mount "type=bind,src=$cqfd_user_home/.gitconfig,dst=$cqfd_user_home/.gitconfig")
+	fi
+
+	if [ "$CQFD_BIND_DOCKER_SOCK" = true ]; then
+		args+=(-v /var/run/docker.sock:/var/run/docker.sock)
 	fi
 
 	args+=(-v "$cqfd_project_dir:$cqfd_project_dir")
@@ -440,6 +460,12 @@ for g in ${CQFD_GROUPS}; do
 
 	usermod -a -G \$group $cqfd_user || die "usermod command failed while adding group \${group}."
 done
+
+# Add docker group as cqfd to cqfd_user
+if [ "${cqfd_docker_gid:-0}" -gt 0 ]; then
+	groupadd -og "$cqfd_docker_gid" -f cqfd || die "groupadd command failed."
+	usermod -a -G cqfd $cqfd_user || die "usermod command failed while adding group cqfd."
+fi	
 
 # run provided command in the working directory
 cd "$cqfd_user_cwd" || die "Changing directory to \"$cqfd_user_cwd\" failed."

--- a/tests/10-cqfd_doutofd
+++ b/tests/10-cqfd_doutofd
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# validate the behavior of running docker in cqfd using host docker daemon
+
+set -o pipefail
+
+. "$(dirname "$0")/jtest.inc" "$1"
+cqfd="$TDIR/.cqfd/cqfd"
+
+cd "$TDIR/" || exit 1
+
+cqfdrc_old=$(mktemp)
+cp -f .cqfdrc "$cqfdrc_old"
+dockerfile_old=$(mktemp)
+cp -f .cqfd/docker/Dockerfile "$dockerfile_old"
+
+jtest_prepare "cqfd run docker using host docker daemon"
+if getent group docker | grep -q "$USER"; then
+	cp -f .cqfd/docker/Dockerfile.doutofd .cqfd/docker/Dockerfile
+	cat "$cqfdrc_old" - <<EOF >.cqfdrc
+
+[doutofd]
+command='docker run --rm -ti ubuntu:24.04 cat /etc/os-release'
+docker_build_args="--build-arg DOCKER_GID=$(getent group docker | cut -d: -f3)"
+docker_run_args="-v /var/run/docker.sock:/var/run/docker.sock"
+user_extra_groups='docker'
+EOF
+
+	if $cqfd -b doutofd init && $cqfd -b doutofd | grep -q 'PRETTY_NAME="Ubuntu 24.04 LTS"'; then
+		jtest_result pass
+	else
+		jtest_result fail
+	fi
+else
+	jtest_result skip
+fi
+
+mv -f "$cqfdrc_old" .cqfdrc
+mv -f "$dockerfile_old" .cqfd/docker/Dockerfile

--- a/tests/10-cqfd_doutofd
+++ b/tests/10-cqfd_doutofd
@@ -17,16 +17,9 @@ cp -f .cqfd/docker/Dockerfile "$dockerfile_old"
 jtest_prepare "cqfd run docker using host docker daemon"
 if getent group docker | grep -q "$USER"; then
 	cp -f .cqfd/docker/Dockerfile.doutofd .cqfd/docker/Dockerfile
-	cat "$cqfdrc_old" - <<EOF >.cqfdrc
+	sed -i -e "/\[build\]/,/^$/s,^command=.*$,command='docker run --rm -ti ubuntu:24.04 cat /etc/os-release'," .cqfdrc
 
-[doutofd]
-command='docker run --rm -ti ubuntu:24.04 cat /etc/os-release'
-docker_build_args="--build-arg DOCKER_GID=$(getent group docker | cut -d: -f3)"
-docker_run_args="-v /var/run/docker.sock:/var/run/docker.sock"
-user_extra_groups='docker'
-EOF
-
-	if $cqfd -b doutofd init && $cqfd -b doutofd | grep -q 'PRETTY_NAME="Ubuntu 24.04 LTS"'; then
+	if $cqfd init && CQFD_BIND_DOCKER_SOCK=true $cqfd | grep -q 'PRETTY_NAME="Ubuntu 24.04 LTS"'; then
 		jtest_result pass
 	else
 		jtest_result fail

--- a/tests/test_data/.cqfd/docker/Dockerfile.doutofd
+++ b/tests/test_data/.cqfd/docker/Dockerfile.doutofd
@@ -1,0 +1,5 @@
+FROM debian:bookworm
+ARG DOCKER_GID
+RUN groupadd -g "${DOCKER_GID}" docker
+RUN apt-get update && apt-get install -y sudo
+RUN apt-get update && apt-get install -y docker.io

--- a/tests/test_data/.cqfd/docker/Dockerfile.doutofd
+++ b/tests/test_data/.cqfd/docker/Dockerfile.doutofd
@@ -1,5 +1,3 @@
 FROM debian:bookworm
-ARG DOCKER_GID
-RUN groupadd -g "${DOCKER_GID}" docker
 RUN apt-get update && apt-get install -y sudo
 RUN apt-get update && apt-get install -y docker.io


### PR DESCRIPTION
This provides an example on how to run cqfd with docker-out-of-docker.

See #136.