### PR TITLE
ci: do not create .gitconfig dir

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -18,4 +18,4 @@ jobs:
       run: make check
 
     - name: Run tests
-      run: make tests GIT_CONFIG_GLOBAL=/dev/null
+      run: make tests

--- a/cqfd
+++ b/cqfd
@@ -300,8 +300,8 @@ docker_run() {
 		args+=(-e "SSH_AUTH_SOCK=$cqfd_user_home/.sockets/ssh")
 	fi
 
-	if [ "$CQFD_NO_USER_GIT_CONFIG" != true ]; then
-		args+=(-v "$cqfd_user_home/.gitconfig:$cqfd_user_home/.gitconfig")
+	if [ "$CQFD_NO_USER_GIT_CONFIG" != true ] && [ -f "$cqfd_user_home/.gitconfig" ]; then
+		args+=(--mount "type=bind,src=$cqfd_user_home/.gitconfig,dst=$cqfd_user_home/.gitconfig")
 	fi
 
 	args+=(-v "$cqfd_project_dir:$cqfd_project_dir")


### PR DESCRIPTION
The docker run -v option creates a directory if the path specified as a source does not exists, whereas the --mount option does not, and is recommended by Docker over --volume