### PR TITLE
cqfd: add bash option pipefail

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -18,6 +18,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 set -e
+set -o pipefail
 
 PROGNAME=$(basename "$0")
 VERSION=5.6.1-dev


### PR DESCRIPTION
This adds the bash option pipefail so that the whole pipeline of commands fails if any of its commands fails.

According to bash(1):

	SHELL GRAMMAR

	Pipelines

	(...)

	The return status of a pipeline is the exit status of the last
	command, unless the pipefail option is enabled. If pipefail is
	enabled, the pipeline's return status is the value of the last
	(rightmost) command to exit with a non-zero status, or zero if
	all commands exit successfully. If the reserved word ! precedes
	a pipeline, the exit status of that pipeline is the logical
	negation of the exit status as described above. The shell waits
	for all commands in the pipeline to terminate before returning a
	value.

	(...)

	SHELL BUILTIN COMMANDS

	set [-abefhkmnptuvxBCEHPT] [-o option-name] [--] [-] [arg ...]
	set [+abefhkmnptuvxBCEHPT] [+o option-name] [--] [-] [arg ...]

	(...)

	-o option-name

	The option-name can be one of the following:

	(...)

	pipefail

	If set, the return value of a pipeline is the value of the last
	(rightmost) command to exit with a non-zero status, or zero if
	all commands in the pipeline exit su ccessfully. This option is
	disabled by default.