### PR TITLE
cqfd: add sh option errexit

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -422,7 +422,7 @@ test_su_session_command() {
 }
 
 debug() {
-	test -n "\$CQFD_DEBUG" && echo "debug: \$*"
+	test -z "\$CQFD_DEBUG" || echo "debug: \$*"
 }
 
 # Check container requirements

--- a/cqfd
+++ b/cqfd
@@ -408,6 +408,8 @@ make_launcher() {
 #!/bin/sh
 # create container user to match expected environment
 
+set -e
+
 die() {
 	echo "error: \$*" >&2
 	exit 1
@@ -442,11 +444,10 @@ if ! shell=\$(command -v "$cqfd_shell"); then
 	echo "$cqfd_shell: command not found" >&2
 	exit 127
 fi
-groupadd -og "${GROUPS[0]}" -f builders || die "groupadd command failed."
-useradd -s "\$shell" -oN -u "$UID" -g "${GROUPS[0]}" -d "$cqfd_user_home" "$cqfd_user" \
-	|| die "useradd command failed."
-mkdir -p "$cqfd_user_home" || die "mkdir command failed."
-chown "$UID:${GROUPS[0]}" "$cqfd_user_home" || die "chown command failed."
+groupadd -og "${GROUPS[0]}" -f builders
+useradd -s "\$shell" -oN -u "$UID" -g "${GROUPS[0]}" -d "$cqfd_user_home" "$cqfd_user"
+mkdir -p "$cqfd_user_home"
+chown "$UID:${GROUPS[0]}" "$cqfd_user_home"
 
 # Add specified groups to cqfd_user
 for g in ${CQFD_GROUPS}; do
@@ -455,20 +456,20 @@ for g in ${CQFD_GROUPS}; do
 
 	if [ -n "\$gid" ]; then
 		# create group with provided id ("name:123")
-		groupadd -og "\$gid" -f "\$group" || die "groupadd failed for \$group."
+		groupadd -og "\$gid" -f "\$group"
 	fi
 
-	usermod -a -G \$group $cqfd_user || die "usermod command failed while adding group \${group}."
+	usermod -a -G \$group $cqfd_user
 done
 
 # Add docker group as cqfd to cqfd_user
 if [ "${cqfd_docker_gid:-0}" -gt 0 ]; then
-	groupadd -og "$cqfd_docker_gid" -f cqfd || die "groupadd command failed."
-	usermod -a -G cqfd $cqfd_user || die "usermod command failed while adding group cqfd."
+	groupadd -og "$cqfd_docker_gid" -f cqfd
+	usermod -a -G cqfd $cqfd_user
 fi	
 
 # run provided command in the working directory
-cd "$cqfd_user_cwd" || die "Changing directory to \"$cqfd_user_cwd\" failed."
+cd "$cqfd_user_cwd"
 if [ -n "\$has_sudo" ]; then
 	debug "Using \"sudo\" to execute command sh -c \"\$1\" as user \"$cqfd_user\""
 	sudo -E -u $cqfd_user sh -c "\$1"

--- a/cqfd
+++ b/cqfd
@@ -422,7 +422,7 @@ test_su_session_command() {
 }
 
 debug() {
-      test -n "\$CQFD_DEBUG" && echo "debug: \$*"
+	test -n "\$CQFD_DEBUG" && echo "debug: \$*"
 }
 
 # Check container requirements

--- a/cqfd
+++ b/cqfd
@@ -415,16 +415,16 @@ die() {
 	exit 1
 }
 
+debug() {
+	test -z "\$CQFD_DEBUG" || echo "debug: \$*"
+}
+
 test_cmd() {
 	command -v "\$1" > /dev/null 2>&1
 }
 
 test_su_session_command() {
 	su --session-command true > /dev/null 2>&1
-}
-
-debug() {
-	test -z "\$CQFD_DEBUG" || echo "debug: \$*"
 }
 
 # Check container requirements


### PR DESCRIPTION
This adds the sh option errexit so that the launcher script exits
immediately if a pipeline, a list, or a compound command exits with a
non-zero status.

According to bash(1):

	SHELL BUILTIN COMMANDS

	set [-abefhkmnptuvxBCEHPT] [-o option-name] [--] [-] [arg ...]
	set [+abefhkmnptuvxBCEHPT] [+o option-name] [--] [-] [arg ...]

	(...)

	-e

	Exit immediately if a pipeline (which may consist of a single
	simple command), a list, or a compound command (see SHELL
	GRAMMAR above), exits with a non-zero status. The shell does not
	exit if the command that fails is part of the command list
	immediately following a while or until keyword, part of the test
	following the if or elif reserved words, part of any command
	executed in a && or || list except the command following the
	final && or ||, any command in a pipeline but the last, or if
	the command's return value is being inverted with !. If a
	compound command other than a subshell returns a non-zero status
	because a command failed while -e was being ignored, the shell
	does not exit. A trap on ERR, if set, is executed before the
	shell exits. This option applies to the shell environment and
	each subshell environment separately (see COMMAND EXECUTION
	ENVIRONMENT above), and may cause subshells to exit before
	executing all the commands in the subshell.

	If a compound command or shell function executes in a context
	where -e is being ignored, none of the commands executed within
	the compound command or function body will be affected by the -e
	setting, even if -e is set and a command returns a failure
	status. If a compound command or shell function sets -e while
	executing in a context where -e is ignored, that setting will
	not have any effect until the compound command or the command
	containing the function call completes.