### PR TITLE
Fix "tests: use bash option pipefail"

### DIFF
--- a/tests/05-cqfd_run_extra_groups
+++ b/tests/05-cqfd_run_extra_groups
@@ -2,7 +2,7 @@
 #
 # validate the behavior of run command with extra groups
 
-set -o pipefile
+set -o pipefail
 
 . "$(dirname "$0")"/jtest.inc "$1"
 cqfd="$TDIR/.cqfd/cqfd"


### PR DESCRIPTION
This fixes commit ae619157e57db40049371abfbdd7958349b6ca5a.