### PR TITLE
tests: reset CQFD_ environment to empty values

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,5 +1,14 @@
 .PHONY: tests check
 
+tests: CQFD_DOCKER =
+tests: CQFD_EXTRA_RUN_ARGS =
+tests: CQFD_EXTRA_BUILD_ARGS =
+tests: CQFD_NO_SSH_CONFIG =
+tests: CQFD_NO_USER_SSH_CONFIG =
+tests: CQFD_NO_USER_GIT_CONFIG =
+tests: CQFD_BIND_DOCKER_SOCK =
+tests: CQFD_DOCKER_GID =
+tests: CQFD_SHELL =
 tests:
 	@$(eval TDIR=$(shell mktemp -d))
 	@for f in [0-9][0-9]*; do \


### PR DESCRIPTION
cqfd uses several environment variables and the integration tests test them.

Therefore, the testing environment alters the tests if these environment are set to some values.

This resets all the CQFD_ environment variables to empty values to prevent the testing environment to polute the tests.

Important: These variables remain overridable thanks to the make command line. The command below runs the test using podman backend:

	$ make CQFD_DOCKER=podman