### PR TITLE
Run sudo if not in docker group

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,9 @@ docker socket to the container.
 ``CQFD_DOCKER_GID``: The gid of the docker group in host to map to
 the cqfd group in the container.
 
+``CQFD_RUN_WITH_SUDO``: Set to ``true`` to run `$CQFD_DOCKER` with
+``sudo``.
+
 ``CQFD_SHELL``: The shell to be launched, by default ``/bin/sh``.
 
 ### Appending to the build command ###

--- a/cqfd
+++ b/cqfd
@@ -28,8 +28,9 @@ cqfd_user="${USER:-builder}"
 cqfd_home="${HOME:-/home/$cqfd_user}"
 cqfd_cwd="${PWD:-$cqfd_home/src}"
 cqfd_shell=${CQFD_SHELL:-/bin/bash}
+# shellcheck disable=SC2162
+read -a cqfd_docker <<<"${CQFD_DOCKER:-docker}"
 cqfd_docker_gid="${CQFD_DOCKER_GID:-0}"
-cqfd_docker="${CQFD_DOCKER:-docker}"
 
 ## usage() - print usage on stdout
 usage() {
@@ -147,14 +148,14 @@ docker_build() {
 		args+=("$project_build_context" -f "$dockerfile")
 	fi
 
-	debug executing: "${cqfd_docker}" build "${args[@]}"
-	"${cqfd_docker}" build "${args[@]}"
+	debug executing: "${cqfd_docker[@]}" build "${args[@]}"
+	"${cqfd_docker[@]}" build "${args[@]}"
 }
 
 # image_exists_locally(): checks if image exists in the local image store
 # arg$1: the image name to check
 image_exists_locally() {
-	"${cqfd_docker}" image inspect "$1" &> /dev/null
+	"${cqfd_docker[@]}" image inspect "$1" &> /dev/null
 }
 
 # docker_run() - run command in configured container
@@ -178,7 +179,7 @@ docker_run() {
 	if ! image_exists_locally "$docker_img_name"; then
 		# If custom image name is used, try to pull it before dying
 		if [ "$project_custom_img_name" ]; then
-			if ! "${cqfd_docker}" pull "$docker_img_name" >& /dev/null; then
+			if ! "${cqfd_docker[@]}" pull "$docker_img_name" >& /dev/null; then
 				die "Custom image couldn't be pulled, please build/upload it first"
 			fi
 		else
@@ -291,8 +292,8 @@ docker_run() {
 
 	args+=("$docker_img_name" cqfd_launch "$1")
 
-	debug executing: "${cqfd_docker}" run "${args[@]}"
-	"${cqfd_docker}" run "${args[@]}"
+	debug executing: "${cqfd_docker[@]}" run "${args[@]}"
+	"${cqfd_docker[@]}" run "${args[@]}"
 }
 
 # make_archive(): Create a release package.
@@ -590,6 +591,11 @@ config_load() {
 				fi
 			done
 		fi
+	fi
+
+	# Use sudo if user is not in the docker group
+	if [ "$CQFD_RUN_WITH_SUDO" = true ] && [ "$cqfd_docker_gid" -eq 0 ]; then
+		cqfd_docker=(sudo "${cqfd_docker[@]}")
 	fi
 }
 

--- a/cqfd
+++ b/cqfd
@@ -212,21 +212,6 @@ docker_run() {
 		args+=(-t)
 	fi
 
-	# Get the docker gid if the group exists
-	if [ "$cqfd_docker_gid" -eq 0 ]; then
-		local docker_group
-		if IFS=: read -r -a docker_group < <(getent group docker); then
-			local docker_users
-			IFS=, read -r -a docker_users <<<"${docker_group[3]}"
-			for user in "${docker_users[@]}"; do
-				if [ "$user" = "$cqfd_user" ]; then
-					cqfd_docker_gid="${docker_group[2]}"
-					break
-				fi
-			done
-		fi
-	fi
-
 	# Display a warning message if using no more supported options
 	if [ -n "$CQFD_EXTRA_VOLUMES" ]; then
 		die 'Warning: CQFD_EXTRA_VOLUMES is no more supported, use
@@ -590,6 +575,21 @@ config_load() {
 	# Adapt things for a specific container
 	if [ -n "$distro" ]; then
 		docker_img_name+="_$distro"
+	fi
+
+	# Get the docker gid if the group exists
+	if [ "$cqfd_docker_gid" -eq 0 ]; then
+		local docker_group
+		if IFS=: read -r -a docker_group < <(getent group docker); then
+			local docker_users
+			IFS=, read -r -a docker_users <<<"${docker_group[3]}"
+			for user in "${docker_users[@]}"; do
+				if [ "$user" = "$cqfd_user" ]; then
+					cqfd_docker_gid="${docker_group[2]}"
+					break
+				fi
+			done
+		fi
 	fi
 }
 

--- a/cqfd
+++ b/cqfd
@@ -24,9 +24,9 @@ PROGNAME=$(basename "$0")
 VERSION=5.6.1-dev
 cqfddir=".cqfd"
 cqfdrc=".cqfdrc"
-cqfd_user='builder'
-cqfd_user_home='/home/builder'
-cqfd_user_cwd="$cqfd_user_home/src"
+cqfd_user="${USER:-builder}"
+cqfd_user_home="${HOME:-/home/$cqfd_user}"
+cqfd_user_cwd="${PWD:-$cqfd_user_home/src}"
 cqfd_shell=${CQFD_SHELL:-/bin/bash}
 cqfd_docker_gid="${CQFD_DOCKER_GID:-0}"
 cqfd_docker="${CQFD_DOCKER:-docker}"
@@ -210,16 +210,6 @@ docker_run() {
 	# allocate a pty if stdin/err are connected to a tty
 	if [ -t 0 ] && [ -t 2 ]; then
 		args+=(-t)
-	fi
-
-	# If possible, map cqfd_user from the calling user's
-	if [ -n "$USER" ]; then
-		cqfd_user="$USER"
-	fi
-
-	if [ -n "$HOME" ]; then
-		cqfd_user_home="$(cd "$HOME"; pwd)"
-		cqfd_user_cwd="$(pwd)"
 	fi
 
 	# Get the docker gid if the group exists

--- a/cqfd
+++ b/cqfd
@@ -25,8 +25,8 @@ VERSION=5.6.1-dev
 cqfddir=".cqfd"
 cqfdrc=".cqfdrc"
 cqfd_user="${USER:-builder}"
-cqfd_user_home="${HOME:-/home/$cqfd_user}"
-cqfd_user_cwd="${PWD:-$cqfd_user_home/src}"
+cqfd_home="${HOME:-/home/$cqfd_user}"
+cqfd_cwd="${PWD:-$cqfd_home/src}"
 cqfd_shell=${CQFD_SHELL:-/bin/bash}
 cqfd_docker_gid="${CQFD_DOCKER_GID:-0}"
 cqfd_docker="${CQFD_DOCKER:-docker}"
@@ -164,7 +164,7 @@ image_exists_locally() {
 #   named after $cqfd_user, with the same uid/gid as your user to keep
 #   filesystem permissions in sync.
 #
-# - Your project's source directory is always mapped to $cqfd_user_cwd
+# - Your project's source directory is always mapped to $cqfd_cwd
 #
 # - Your ~/.ssh directory is mapped to ~${cqfd_user}/.ssh to provide
 #   access to the ssh keys (your build may pull authenticated git
@@ -265,7 +265,7 @@ docker_run() {
 
 	# Set HOME variable for the $cqfd_user, except if it was
 	# explicitely set via CQFD_EXTRA_RUN_ARGS
-	local home_env_var="HOME=$cqfd_user_home"
+	local home_env_var="HOME=$cqfd_home"
 	if echo "$CQFD_EXTRA_RUN_ARGS" | grep -qE "(-e[[:blank:]]*|--env[[:blank:]]+)HOME="; then
 		home_env_var=""
 	fi
@@ -275,7 +275,7 @@ docker_run() {
 	fi
 
 	if [ "$CQFD_NO_USER_SSH_CONFIG" != true ]; then
-		args+=(-v "$cqfd_user_home/.ssh:$cqfd_user_home/.ssh")
+		args+=(-v "$cqfd_home/.ssh:$cqfd_home/.ssh")
 	fi
 
 	if [ "$CQFD_NO_SSH_CONFIG" != true ]; then
@@ -283,12 +283,12 @@ docker_run() {
 	fi
 
 	if [ "$SSH_AUTH_SOCK" ]; then
-		args+=(-v "$SSH_AUTH_SOCK:$cqfd_user_home/.sockets/ssh")
-		args+=(-e "SSH_AUTH_SOCK=$cqfd_user_home/.sockets/ssh")
+		args+=(-v "$SSH_AUTH_SOCK:$cqfd_home/.sockets/ssh")
+		args+=(-e "SSH_AUTH_SOCK=$cqfd_home/.sockets/ssh")
 	fi
 
-	if [ "$CQFD_NO_USER_GIT_CONFIG" != true ] && [ -f "$cqfd_user_home/.gitconfig" ]; then
-		args+=(--mount "type=bind,src=$cqfd_user_home/.gitconfig,dst=$cqfd_user_home/.gitconfig")
+	if [ "$CQFD_NO_USER_GIT_CONFIG" != true ] && [ -f "$cqfd_home/.gitconfig" ]; then
+		args+=(--mount "type=bind,src=$cqfd_home/.gitconfig,dst=$cqfd_home/.gitconfig")
 	fi
 
 	if [ "$CQFD_BIND_DOCKER_SOCK" = true ]; then
@@ -437,9 +437,9 @@ fi
 
 # Add the host's user and group to the container, and adjust ownership
 groupadd -og "${GROUPS[0]}" -f builders
-useradd -s "\$shell" -oN -u "$UID" -g "${GROUPS[0]}" -d "$cqfd_user_home" "$cqfd_user"
-mkdir -p "$cqfd_user_home"
-chown "$UID:${GROUPS[0]}" "$cqfd_user_home"
+useradd -s "\$shell" -oN -u "$UID" -g "${GROUPS[0]}" -d "$cqfd_home" "$cqfd_user"
+mkdir -p "$cqfd_home"
+chown "$UID:${GROUPS[0]}" "$cqfd_home"
 
 # Add specified groups to cqfd_user
 for g in ${CQFD_GROUPS}; do
@@ -461,7 +461,7 @@ if [ "${cqfd_docker_gid:-0}" -gt 0 ]; then
 fi	
 
 # Change to the working directory
-cd "$cqfd_user_cwd"
+cd "$cqfd_cwd"
 
 # Drop the root privileges and run providing command, using sudo if it exists
 if [ -n "\$has_sudo" ]; then


### PR DESCRIPTION
The docker client requires to run as root in rootfull mode. The docker
group allows a user to access to the Unix socket created by the docker
daemon.

The user needs to run docker client with more privileges (i.e. sudo) if
it is not part of that group[1].

This prepends sudo to CQFD_DOCKER automatically if CQFD_RUN_WITH_SUDO is
set to true. It turns the internal variable cqfd_docket into an array to
split the command into pieces ("sudo docker" -> "sudo" and "docker").

[1]: https://docs.docker.com/install/linux/linux-postinstall/#manage-docker-as-a-non-root-user