### PR TITLE
tests: fix grep in doutofd

### DIFF
--- a/tests/10-cqfd_doutofd
+++ b/tests/10-cqfd_doutofd
@@ -19,7 +19,7 @@ if getent group docker | grep -q "$USER"; then
 	cp -f .cqfd/docker/Dockerfile.doutofd .cqfd/docker/Dockerfile
 	sed -i -e "/\[build\]/,/^$/s,^command=.*$,command='docker run --rm -ti ubuntu:24.04 cat /etc/os-release'," .cqfdrc
 
-	if $cqfd init && CQFD_BIND_DOCKER_SOCK=true $cqfd | grep -q 'PRETTY_NAME="Ubuntu 24.04 LTS"'; then
+	if "$cqfd" init && CQFD_BIND_DOCKER_SOCK=true "$cqfd" | grep -q 'PRETTY_NAME="Ubuntu 24.04 LTS"'; then
 		jtest_result pass
 	else
 		jtest_result fail

--- a/tests/10-cqfd_doutofd
+++ b/tests/10-cqfd_doutofd
@@ -19,7 +19,7 @@ if getent group docker | grep -q "$USER"; then
 	cp -f .cqfd/docker/Dockerfile.doutofd .cqfd/docker/Dockerfile
 	sed -i -e "/\[build\]/,/^$/s,^command=.*$,command='docker run --rm -ti ubuntu:24.04 cat /etc/os-release'," .cqfdrc
 
-	if "$cqfd" init && CQFD_BIND_DOCKER_SOCK=true "$cqfd" | grep -q 'PRETTY_NAME="Ubuntu 24.04 LTS"'; then
+	if "$cqfd" init && CQFD_BIND_DOCKER_SOCK=true "$cqfd" | grep -qE 'PRETTY_NAME="Ubuntu 24.04(.[[:digit:]]+)? LTS"'; then
 		jtest_result pass
 	else
 		jtest_result fail


### PR DESCRIPTION
The Ubuntu version number can be updated so we include a regex in the
grep statement