### PR TITLE
Simplify ini parsing once again

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -88,13 +88,13 @@ parse_ini_config_file() {
 	ini=( "${ini[@]/=$'\t'/=}" )                 # remove tabs after =
 	ini=( "${ini[@]/\ =/=}" )                    # remove space before =
 	ini=( "${ini[@]/=\ /=}" )                    # remove space after =
-	ini=( "${ini[@]/#\\[/\}$'\n'cfg.section.}" ) # set section prefix
+	ini=( "${ini[@]/#\\[/$':\n}\ncfg.section.'}" ) # set section prefix
 	ini=( "${ini[@]/%\\]/(}" )                   # convert text2function (1)
 	ini=( "${ini[@]/%(/()}" )                    # close array parenthesis
 	ini=( "${ini[@]/%\)/) {}" )                  # the multiline trick
 	ini=( "${ini[@]/%\( \)/\(\) \{}" )           # convert text2function (2)
 	ini=( "${ini[@]/%\} \)/\}}" )                # remove extra parenthesis
-	ini+=( "}" )                                 # add the last brace
+	ini+=( $':\n}' )                             # add the last brace
 	ini[0]="${ini[0]/\}/}"                       # remove the first brace
 	ini=("$(printf "%s\n" "${ini[@]}")")         # reconvert to line-array
 	if ! eval "${ini[*]}"; then                  # eval the result

--- a/cqfd
+++ b/cqfd
@@ -94,8 +94,8 @@ parse_ini_config_file() {
 	ini=( "${ini[@]/%\)/) {}" )                  # the multiline trick
 	ini=( "${ini[@]/%\( \)/\(\) \{}" )           # convert text2function (2)
 	ini=( "${ini[@]/%\} \)/\}}" )                # remove extra parenthesis
-	ini[0]="${ini[0]/\}/}"                       # remove the first brace
 	ini+=( "}" )                                 # add the last brace
+	ini[0]="${ini[0]/\}/}"                       # remove the first brace
 	ini=("$(printf "%s\n" "${ini[@]}")")         # reconvert to line-array
 	if ! eval "${ini[*]}"; then                  # eval the result
 		debug "$1: fail to evaluate shell:" "${ini[@]}"
@@ -539,7 +539,11 @@ config_load() {
 		fi
 	done
 
-	cfg.section.project # load the [project] section
+	# load the [project] section
+	if ! cfg.section.project 2>/dev/null; then
+		die "$cqfdrc: Missing project section!"
+	fi
+
 	# shellcheck disable=SC2154
 	project_org="$org"
 	# shellcheck disable=SC2154
@@ -554,7 +558,11 @@ config_load() {
 		die "$cqfdrc: Missing project.org or project.name properties"
 	fi
 
-	cfg.section.build # load the [build] section
+	# load the [build] section
+	if ! cfg.section.build 2>/dev/null; then
+		die "$cqfdrc: Missing build section!"
+	fi
+
 	build_flavors="${flavors[*]}"
 
 	# build parameters may be overriden by a flavor defined in the
@@ -562,7 +570,10 @@ config_load() {
 	local flavor="$1"
 	if [ -n "$flavor" ]; then
 		if grep -qw "$flavor" <<< "${flavors[*]}"; then
-			cfg.section."$flavor" # load the [$flavor] section
+			# load the [$flavor] section
+			if ! cfg.section."$flavor" 2>/dev/null; then
+				die "$cqfdrc: Missing $flavor section!"
+			fi
 		else
 			die "flavor \"$flavor\" not found in flavors list"
 		fi

--- a/cqfd
+++ b/cqfd
@@ -69,11 +69,12 @@ Command options for run / release:
 EOF
 }
 
-# parse_ini_config_file()
+# cfg_parser() - parse ini-style config files
+# Will parse a ini-style config file, and evaluate it to a bash array.
 #   Ref: https://ajdiaz.wordpress.com/2008/02/09/bash-ini-parser/
 #        by Andrés J. Díaz - License: MIT
 # arg$1: path to ini file
-parse_ini_config_file() {
+cfg_parser() {
 	local ini
 
 	if [ ! -f "$1" ]; then
@@ -521,7 +522,7 @@ config_load() {
 		local cqfdrc_dir="$cqfd_project_dir/"
 	fi
 
-	parse_ini_config_file "${cqfdrc_dir}${cqfdrc}"
+	cfg_parser "${cqfdrc_dir}${cqfdrc}"
 
 	# generate dynamically the list of flavors based on the names of shell
 	# functions reported by the buildtin:

--- a/cqfd
+++ b/cqfd
@@ -80,20 +80,20 @@ parse_ini_config_file() {
 		die "Unable to find $1 - create it or pick one using 'cqfd -f'"
 	fi
 
-	mapfile -t ini <"$1"                         # convert to line-array
-	ini=( "${ini[@]//[/\\[}" )                   # escape [
-	ini=( "${ini[@]//]/\\]}" )                   # escape ]
-	ini=( "${ini[@]//;*/}" )                     # remove comments with ;
-	ini=( "${ini[@]/$'\t'=/=}" )                 # remove tabs before =
-	ini=( "${ini[@]/=$'\t'/=}" )                 # remove tabs after =
-	ini=( "${ini[@]/\ =/=}" )                    # remove space before =
-	ini=( "${ini[@]/=\ /=}" )                    # remove space after =
-	ini=( "${ini[@]/#\\[/$'\n}\nfunction cfg.section.'}" ) # convert section to function (1)
-	ini=( "${ini[@]/%\\]/ { :}" )                          # convert section to function (2)
-	ini+=( "}" )                                 # add the last brace
-	ini[0]="${ini[0]/\}/}"                       # remove the first brace
-	ini=("$(printf "%s\n" "${ini[@]}")")         # reconvert to line-array
-	if ! eval "${ini[*]}"; then                  # eval the result
+	mapfile -t ini <"$1"                                 # convert to line-array
+	ini=("${ini[@]//[/\\[}")                             # escape [
+	ini=("${ini[@]//]/\\]}")                             # escape ]
+	ini=("${ini[@]//;*/}")                               # remove comments with ;
+	ini=("${ini[@]/$'\t'=/=}")                           # remove tabs before =
+	ini=("${ini[@]/=$'\t'/=}")                           # remove tabs after =
+	ini=("${ini[@]/\ =/=}")                              # remove space before =
+	ini=("${ini[@]/=\ /=}")                              # remove space after =
+	ini=("${ini[@]/#\\[/$'\n}\nfunction cfg.section.'}") # convert section to function (1)
+	ini=("${ini[@]/%\\]/ { :}")                          # convert section to function (2)
+	ini+=("}")                                           # add the last brace
+	ini[0]="${ini[0]/\}/}"                               # remove the first brace
+	ini=("$(printf "%s\n" "${ini[@]}")")                 # reconvert to line-array
+	if ! eval "${ini[*]}"; then                          # eval the result
 		debug "$1: fail to evaluate shell:" "${ini[@]}"
 		die "$1: Invalid ini-file!"
 	fi

--- a/cqfd
+++ b/cqfd
@@ -77,10 +77,6 @@ EOF
 cfg_parser() {
 	local ini
 
-	if [ ! -f "$1" ]; then
-		die "Unable to find $1 - create it or pick one using 'cqfd -f'"
-	fi
-
 	mapfile -t ini <"$1"                                 # convert to line-array
 	ini=("${ini[@]//[/\\[}")                             # escape [
 	ini=("${ini[@]//]/\\]}")                             # escape ]
@@ -94,10 +90,7 @@ cfg_parser() {
 	ini+=("}")                                           # add the last brace
 	ini[0]="${ini[0]/\}/}"                               # remove the first brace
 	ini=("$(printf "%s\n" "${ini[@]}")")                 # reconvert to line-array
-	if ! eval "${ini[*]}"; then                          # eval the result
-		debug "$1: fail to evaluate shell:" "${ini[@]}"
-		die "$1: Invalid ini-file!"
-	fi
+	eval "${ini[*]}"                                     # eval the result
 }
 
 ## die() - exit when an error occured
@@ -522,7 +515,13 @@ config_load() {
 		local cqfdrc_dir="$cqfd_project_dir/"
 	fi
 
-	cfg_parser "${cqfdrc_dir}${cqfdrc}"
+	if [ ! -f "${cqfdrc_dir}${cqfdrc}" ]; then
+		die "Unable to find ${cqfdrc_dir}${cqfdrc} - create it or pick one using 'cqfd -f'"
+	fi
+
+	if ! cfg_parser "${cqfdrc_dir}${cqfdrc}"; then
+		die "${cqfdrc_dir}${cqfdrc}: Invalid ini-file!"
+	fi
 
 	# generate dynamically the list of flavors based on the names of shell
 	# functions reported by the buildtin:

--- a/cqfd
+++ b/cqfd
@@ -80,7 +80,7 @@ parse_ini_config_file() {
 		die "Unable to find $1 - create it or pick one using 'cqfd -f'"
 	fi
 
-	mapfile -t ini <"$1"
+	mapfile -t ini <"$1"                         # convert to line-array
 	ini=( "${ini[@]//[/\\[}" )                   # escape [
 	ini=( "${ini[@]//]/\\]}" )                   # escape ]
 	ini=( "${ini[@]//;*/}" )                     # remove comments with ;
@@ -96,7 +96,7 @@ parse_ini_config_file() {
 	ini=( "${ini[@]/%\} \)/\}}" )                # remove extra parenthesis
 	ini[0]="${ini[0]/\}/}"                       # remove the first brace
 	ini+=( "}" )                                 # add the last brace
-	ini=("$(printf "%s\n" "${ini[@]}")")
+	ini=("$(printf "%s\n" "${ini[@]}")")         # reconvert to line-array
 	if ! eval "${ini[*]}"; then                  # eval the result
 		debug "$1: fail to evaluate shell:" "${ini[@]}"
 		die "$1: Invalid ini-file!"

--- a/cqfd
+++ b/cqfd
@@ -89,7 +89,7 @@ cfg_parser() {
 	ini=("${ini[@]/=$'\t'/=}")                           # remove tabs after =
 	ini=("${ini[@]/\ =/=}")                              # remove space before =
 	ini=("${ini[@]/=\ /=}")                              # remove space after =
-	ini=("${ini[@]/#\\[/$'\n}\nfunction cfg.section.'}") # convert section to function (1)
+	ini=("${ini[@]/#\\[/$'\n}\nfunction cfg_section_'}") # convert section to function (1)
 	ini=("${ini[@]/%\\]/ { :}")                          # convert section to function (2)
 	ini+=("}")                                           # add the last brace
 	ini[0]="${ini[0]/\}/}"                               # remove the first brace
@@ -526,10 +526,10 @@ config_load() {
 
 	# generate dynamically the list of flavors based on the names of shell
 	# functions reported by the buildtin:
-	#  - the cfg.section. prefix is stripped
+	#  - the cfg_section_ prefix is stripped
 	#  - the build and project sections are stripped
-	mapfile -t flavors < <(compgen -A function -X '!cfg.section.*')
-	flavors=("${flavors[@]/cfg.section./}")
+	mapfile -t flavors < <(compgen -A function -X '!cfg_section_*')
+	flavors=("${flavors[@]/cfg_section_/}")
 	for i in "${!flavors[@]}"; do
 		if [[ "${flavors[$i]}" =~ ^(build|project)$ ]]; then
 			unset 'flavors[$i]'
@@ -537,7 +537,7 @@ config_load() {
 	done
 
 	# load the [project] section
-	if ! cfg.section.project 2>/dev/null; then
+	if ! cfg_section_project 2>/dev/null; then
 		die "$cqfdrc: Missing project section!"
 	fi
 
@@ -556,7 +556,7 @@ config_load() {
 	fi
 
 	# load the [build] section
-	if ! cfg.section.build 2>/dev/null; then
+	if ! cfg_section_build 2>/dev/null; then
 		die "$cqfdrc: Missing build section!"
 	fi
 
@@ -568,7 +568,7 @@ config_load() {
 	if [ -n "$flavor" ]; then
 		if grep -qw "$flavor" <<< "${flavors[*]}"; then
 			# load the [$flavor] section
-			if ! cfg.section."$flavor" 2>/dev/null; then
+			if ! cfg_section_"$flavor" 2>/dev/null; then
 				die "$cqfdrc: Missing $flavor section!"
 			fi
 		else

--- a/cqfd
+++ b/cqfd
@@ -93,6 +93,12 @@ cfg_parser() {
 	eval "${ini[*]}"                                     # eval the result
 }
 
+## warn() - output warning
+# $* messages and variables shown in the message
+warn() {
+	echo "cqfd: warning: $*" >&2
+}
+
 ## die() - exit when an error occured
 # $* messages and variables shown in the error message
 die() {
@@ -681,6 +687,10 @@ while [ $# -gt 0 ]; do
 		if [ "$1" = "-c" ]; then
 			if [ "$#" -lt 2 ]; then
 				die "option -c requires arguments"
+			fi
+
+			if [ -z "$build_cmd" ]; then
+				warn "$cqfdrc: Missing or empty build.command property"
 			fi
 
 			shift

--- a/cqfd
+++ b/cqfd
@@ -725,7 +725,7 @@ elif [ -n "$*" ]; then
 fi
 
 if [ -z "$build_cmd" ]; then
-	die "No build.command defined in ${cqfdrc}, and no command specified"
+	die "$cqfdrc: Missing or empty build.command property"
 fi
 
 docker_run "$build_cmd"

--- a/cqfd
+++ b/cqfd
@@ -88,13 +88,9 @@ parse_ini_config_file() {
 	ini=( "${ini[@]/=$'\t'/=}" )                 # remove tabs after =
 	ini=( "${ini[@]/\ =/=}" )                    # remove space before =
 	ini=( "${ini[@]/=\ /=}" )                    # remove space after =
-	ini=( "${ini[@]/#\\[/$':\n}\ncfg.section.'}" ) # set section prefix
-	ini=( "${ini[@]/%\\]/(}" )                   # convert text2function (1)
-	ini=( "${ini[@]/%(/()}" )                    # close array parenthesis
-	ini=( "${ini[@]/%\)/) {}" )                  # the multiline trick
-	ini=( "${ini[@]/%\( \)/\(\) \{}" )           # convert text2function (2)
-	ini=( "${ini[@]/%\} \)/\}}" )                # remove extra parenthesis
-	ini+=( $':\n}' )                             # add the last brace
+	ini=( "${ini[@]/#\\[/$'\n}\nfunction cfg.section.'}" ) # convert section to function (1)
+	ini=( "${ini[@]/%\\]/ { :}" )                          # convert section to function (2)
+	ini+=( "}" )                                 # add the last brace
 	ini[0]="${ini[0]/\}/}"                       # remove the first brace
 	ini=("$(printf "%s\n" "${ini[@]}")")         # reconvert to line-array
 	if ! eval "${ini[*]}"; then                  # eval the result

--- a/cqfd
+++ b/cqfd
@@ -549,6 +549,11 @@ config_load() {
 	# shellcheck disable=SC2154
 	project_custom_img_name="$custom_img_name"
 
+	# check for [project] org and name properties are set and are not empty
+	if [ -z "$project_org" ] || [ -z "$project_name" ]; then
+		die "$cqfdrc: Missing project.org or project.name properties"
+	fi
+
 	cfg.section.build # load the [build] section
 	build_flavors="${flavors[*]}"
 
@@ -581,11 +586,6 @@ config_load() {
 	release_tar_opts="$tar_options"
 
 	dockerfile="${cqfd_project_dir}/${cqfddir}/${distro:-docker}/Dockerfile"
-
-	if [ -z "$project_org" ] || [ -z "$project_name" ]; then
-		die "Please set project.org and project.name in .cqfdrc"
-	fi
-
 	if [ ! -f "$dockerfile" ]; then
 		die "$dockerfile not found"
 	fi

--- a/tests/03-cqfdrc_error
+++ b/tests/03-cqfdrc_error
@@ -9,6 +9,17 @@ cd "$TDIR/" || exit 1
 
 cqfdrc_old=$(mktemp)
 cp -f .cqfdrc "$cqfdrc_old"
+
+echo -n "" >.cqfdrc
+
+jtest_prepare "cqfdrc fails file is empty"
+if ! "$cqfd" run true; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
+cp -f "$cqfdrc_old" .cqfdrc
 echo "foo	=bar" >>.cqfdrc
 
 jtest_prepare "cqfdrc with tabulation before should pass"

--- a/tests/03-cqfdrc_error
+++ b/tests/03-cqfdrc_error
@@ -69,6 +69,14 @@ else
 	jtest_result fail
 fi
 
+jtest_prepare "cqfdrc succeeds even if no command property set in build section using run -c"
+if "$cqfd" run -c true 2>&1 | grep "cqfd: warning: .cqfdrc: Missing or empty build.command property";
+   test "${PIPESTATUS[0]}" -eq 0 -a "${PIPESTATUS[1]}" -eq 0; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
 cp -f "$cqfdrc_old" .cqfdrc
 echo "foo	=bar" >>.cqfdrc
 

--- a/tests/03-cqfdrc_error
+++ b/tests/03-cqfdrc_error
@@ -2,6 +2,8 @@
 #
 # validate the .cqfdrc syntax
 
+set -o pipefail
+
 . "$(dirname "$0")"/jtest.inc "$1"
 cqfd="$TDIR/.cqfd/cqfd"
 
@@ -12,8 +14,56 @@ cp -f .cqfdrc "$cqfdrc_old"
 
 echo -n "" >.cqfdrc
 
-jtest_prepare "cqfdrc fails file is empty"
-if ! "$cqfd" run true; then
+jtest_prepare "cqfdrc fails if no project section"
+if "$cqfd" 2>&1 | grep "cqfd: fatal: .cqfdrc: Missing project section!";
+   test "${PIPESTATUS[0]}" -eq 1 -a "${PIPESTATUS[1]}" -eq 0; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
+echo "[project]" >>.cqfdrc
+
+jtest_prepare "cqfdrc fails if no name property set in project section"
+if "$cqfd" 2>&1 | grep "cqfd: fatal: .cqfdrc: Missing project.org or project.name properties";
+   test "${PIPESTATUS[0]}" -eq 1 -a "${PIPESTATUS[1]}" -eq 0; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
+echo "name=test" >>.cqfdrc
+
+jtest_prepare "cqfdrc fails if no org property set in project section"
+if "$cqfd" 2>&1 | grep "cqfd: fatal: .cqfdrc: Missing project.org or project.name properties";
+   test "${PIPESTATUS[0]}" -eq 1 -a "${PIPESTATUS[1]}" -eq 0; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
+echo "org=test" >>.cqfdrc
+
+jtest_prepare "cqfdrc fails if no build section"
+if "$cqfd" 2>&1 | grep "cqfd: fatal: .cqfdrc: Missing build section!";
+   test "${PIPESTATUS[0]}" -eq 1 -a "${PIPESTATUS[1]}" -eq 0; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
+echo "[build]" >>.cqfdrc
+
+jtest_prepare "cqfdrc fails if no command property set in build section"
+if "$cqfd" 2>&1 | grep "cqfd: fatal: No build.command defined in .cqfdrc, and no command specified"
+   test "${PIPESTATUS[0]}" -eq 1 -a "${PIPESTATUS[1]}" -eq 0; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
+jtest_prepare "cqfdrc succeeds if project and build sections are set correctly"
+if "$cqfd" init && "$cqfd" run true; then
 	jtest_result pass
 else
 	jtest_result fail

--- a/tests/03-cqfdrc_error
+++ b/tests/03-cqfdrc_error
@@ -55,7 +55,7 @@ fi
 echo "[build]" >>.cqfdrc
 
 jtest_prepare "cqfdrc fails if no command property set in build section"
-if "$cqfd" 2>&1 | grep "cqfd: fatal: No build.command defined in .cqfdrc, and no command specified"
+if "$cqfd" 2>&1 | grep "cqfd: fatal: .cqfdrc: Missing or empty build.command property";
    test "${PIPESTATUS[0]}" -eq 1 -a "${PIPESTATUS[1]}" -eq 0; then
 	jtest_result pass
 else


### PR DESCRIPTION
Hello,

Surprisingly, I found commits of an old age in my repository :)

With this PR, I check if the sections `[project]` and `[build]` (including eventually the flavor section), and `cqfd` die with an appropriate message, as soon as possible.

Also, I check it the required properties `org`, `name` and `command` are set, and die as soon as possible.

The user is guided by the messages to build its own `.cqfdrc` file; i.e. hitting the wall one after the other.

Additionally, I have modified the ini parser even more by simplifying the translation the .ini to shell (using keyword `function` that do not need the parenthesis). Also, the parser, allows to parse empty files and empty sections.

Of courses, I have added more tests for these changes ;)

Kind Regards,
Gaël