### PR TITLE
Propagate verbose to launcher

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -415,7 +415,7 @@ die() {
 }
 
 debug() {
-	test -z "\$CQFD_DEBUG" || echo "debug: \$*"
+	test -z "$CQFD_DEBUG" || echo "debug: \$*"
 }
 
 test_cmd() {

--- a/tests/05-cqfd_run_check_dependencies
+++ b/tests/05-cqfd_run_check_dependencies
@@ -30,7 +30,6 @@ fi
 # Add Bash and the 'shadow' package, which provides useradd, groupadd.
 ################################################################################
 echo 'RUN apk add bash shadow' >> .cqfd/docker/Dockerfile
-echo 'ENV CQFD_DEBUG=1' >> .cqfd/docker/Dockerfile
 
 ################################################################################
 # cqfd run should now be happy with the required commands, using su.
@@ -39,7 +38,7 @@ jtest_prepare "cqfd run with satisfied command requirements, using su"
 if [ "$cqfd_docker" = "podman" ]; then
 	jtest_result skip
 else
-	if "$cqfd" init && "$cqfd" run true \
+	if "$cqfd" init && "$cqfd" --verbose run true \
 		| awk -v rc=1 '/Using "su"/ { rc=0 } 1; END {exit rc}'; then
 		jtest_result pass
 	else
@@ -59,7 +58,7 @@ jtest_prepare "cqfd run with satisfied command requirements, using sudo"
 if [ "$cqfd_docker" = "podman" ]; then
 	jtest_result skip
 else
-	if "$cqfd" init && "$cqfd" run true \
+	if "$cqfd" init && "$cqfd" --verbose run true \
 		| awk -v rc=1 '/Using "sudo"/ { rc=0 } 1; END {exit rc}'; then
 		jtest_result pass
 	else

--- a/tests/05-cqfd_run_su_or_sudo_backend
+++ b/tests/05-cqfd_run_su_or_sudo_backend
@@ -15,7 +15,6 @@ cd "$TDIR/" || exit 1
 ################################################################################
 cp -f .cqfd/docker/Dockerfile .cqfd/docker/Dockerfile.orig
 echo "FROM ubuntu:16.04" > .cqfd/docker/Dockerfile
-echo "ENV CQFD_DEBUG=1" >> .cqfd/docker/Dockerfile
 
 ################################################################################
 # cqfd run should be happy using su -c.
@@ -24,7 +23,7 @@ jtest_prepare "cqfd run with su -c"
 if [ "$cqfd_docker" = "podman" ]; then
 	jtest_result skip
 else
-	if "$cqfd" init && "$cqfd" run true \
+	if "$cqfd" init && "$cqfd" --verbose run true \
 		| awk -v rc=1 '/Using "su" to execute command/ { rc=0 } 1; END {exit rc}'; then
 		jtest_result pass
 	else
@@ -36,7 +35,6 @@ fi
 # Use another custom Dockerfile with a recent version of su.
 ################################################################################
 echo "FROM ubuntu:24.04" > .cqfd/docker/Dockerfile
-echo "ENV CQFD_DEBUG=1" >> .cqfd/docker/Dockerfile
 
 ################################################################################
 # cqfd run should be happy using su --session-command.
@@ -45,7 +43,7 @@ jtest_prepare "cqfd run with su --session-command"
 if [ "$cqfd_docker" = "podman" ]; then
 	jtest_result skip
 else
-	if "$cqfd" init && "$cqfd" run true \
+	if "$cqfd" init && "$cqfd" --verbose run true \
 		| awk -v rc=1 '/Using "su" to execute session command/ { rc=0 } 1; END {exit rc}'; then
 		jtest_result pass
 	else
@@ -66,7 +64,7 @@ jtest_prepare "cqfd run with sudo"
 if [ "$cqfd_docker" = "podman" ]; then
 	jtest_result skip
 else
-	if "$cqfd" init && "$cqfd" run true \
+	if "$cqfd" init && "$cqfd" --verbose run true \
 		| awk -v rc=1 '/Using "sudo" to execute command/ { rc=0 } 1; END {exit rc}'; then
 		jtest_result pass
 	else


### PR DESCRIPTION
With my recent work on the launcher, I figured out that it is not trivial to enable the debug traces from the CLI as it requires to set the `CQFD_DEBUG` environment to `1` either using the docker-run option `--env CQFD_DEBUG=1` or using the Dockerfile directive `ENV CQFD_DEBUG=1`.

This PR suggests to enable these launcher traces either using `--verbose` (first commit) or using `--verbose` twice (second commit) to preserve the existing behavior that wants to set `CQFD_DEBUG=1` in the container environment (poluting the environment at the same time).