### PR TITLE
Add warning if run command has multiple arguments

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -686,8 +686,14 @@ while [ $# -gt 0 ]; do
 			if [ "$#" -lt 2 ]; then
 				die "option -c requires arguments"
 			fi
-
 			shift
+
+			# Display a warning message if using run -c with multiple arguments
+			if [ "$#" -gt 1 ]; then
+				warn "command run -c shall support a single argument," \
+				     "please consider the command run -c instead:"
+				echo "               cqfd run -c \"$*\"" >&2
+			fi
 			break
 		fi
 

--- a/cqfd
+++ b/cqfd
@@ -103,6 +103,12 @@ parse_ini_config_file() {
 	fi
 }
 
+## warn() - output warning
+# $* messages and variables shown in the message
+warn() {
+	echo "cqfd: warning: $*" >&2
+}
+
 ## die() - exit when an error occured
 # $* messages and variables shown in the error message
 die() {
@@ -687,6 +693,14 @@ while [ $# -gt 0 ]; do
 
 		# Run alternate command
 		has_alternate_command=true
+
+		# Display a warning message if using run with multiple arguments
+		if [ "$#" -ne 1 ]; then
+			warn "command run with multiple arguments is ambigous," \
+			     "please consider the commands exec or shell instead:"
+			echo "               cqfd exec $*" >&2
+			echo "               cqfd shell -c \"$*\"" >&2
+		fi
 		break
 		;;
 	sh|ash|dash|bash|ksh|zsh|csh|tcsh|fish|shell)


### PR DESCRIPTION
Dear Maintainers,

I think the command `run command_string` is ambiguous, and cqfd should tell the user to switch to `cqfd exec PROGRAM [ARGUMENTS...]` if the `command_string` is a single command or to `cqfd shell -c "command_string"` if the `command_string` is a list of command.

More information in 344969c0de765faba5a22c8cb470e4efe63b2047.

What do you think about this?