### PR TITLE
cqfd: optionize release command

### DIFF
--- a/bash-completion
+++ b/bash-completion
@@ -91,7 +91,7 @@ _cqfd() {
 		return
 	fi
 
-	local opts="-C -d -f -b -q -V --version -h --help"
+	local opts="-C -d -f -b -q --release -V --version -h --help"
 	if [[ "$cur" == -* ]]; then
 		COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
 		return

--- a/cqfd
+++ b/cqfd
@@ -37,6 +37,7 @@ usage() {
 Usage: $PROGNAME [OPTIONS] [COMMAND] [COMMAND OPTIONS] [ARGUMENTS]
 
 Options:
+    --release            Release software.
     -f <file>            Use file as config file (default .cqfdrc).
     -d <directory>       Use directory as cqfd directory (default .cqfd).
     -C <directory>       Use the specified working directory.
@@ -655,6 +656,9 @@ while [ $# -gt 0 ]; do
 		;;
 	-q)
 		quiet=true
+		;;
+	--release)
+		has_to_release=true
 		;;
 	exec)
 		if [ "$#" -lt 2 ]; then


### PR DESCRIPTION
This adds the options --release that allows to cqfd release from an
empty command and the command run.

	cqfd [--release] [run] [command_string].