### PR TITLE
tests: 04-cqfd_init_context: fix testing if cqfd init fail

### DIFF
--- a/tests/04-cqfd_init_context
+++ b/tests/04-cqfd_init_context
@@ -12,10 +12,10 @@ cd "$TDIR/" || exit 1
 ################################################################################
 jtest_prepare "cqfd init without using build_context"
 if "$cqfd" init &&
-   "$cqfd" run "test -e /tmp/cqfdrc-build_context"; then
-	jtest_result fail
-else
+   "$cqfd" run "! test -e /tmp/cqfdrc-build_context"; then
 	jtest_result pass
+else
+	jtest_result fail
 fi
 
 ################################################################################

--- a/tests/04-cqfd_init_context
+++ b/tests/04-cqfd_init_context
@@ -2,8 +2,6 @@
 #
 # validate the behavior of project.build_context
 
-set -o pipefail
-
 . "$(dirname "$0")"/jtest.inc "$1"
 cqfd="$TDIR/.cqfd/cqfd"
 
@@ -14,7 +12,7 @@ cd "$TDIR/" || exit 1
 ################################################################################
 jtest_prepare "cqfd init without using build_context"
 if "$cqfd" init &&
-   "$cqfd" run "grep '^build_context=' /tmp/cqfdrc-build_context" | grep -q '^build_cont'; then
+   "$cqfd" run "test -e /tmp/cqfdrc-build_context"; then
 	jtest_result fail
 else
 	jtest_result pass
@@ -32,7 +30,7 @@ cp -f cqfdrc-build_context .cqfdrc
 ################################################################################
 jtest_prepare "cqfd init using build_context"
 if "$cqfd" init &&
-   "$cqfd" run "grep '^build_context=' /tmp/cqfdrc-build_context" | grep -q '^build_cont'; then
+   "$cqfd" run "test -e /tmp/cqfdrc-build_context"; then
 	jtest_result pass
 else
 	jtest_result fail


### PR DESCRIPTION
The first test uses the standard Dockerfile and it does not set the
build_context= (the context is directory holding the Dockerfile, i.e.
the project directory .cqfd/docker).

The file /tmp/cqfdrc-build_context is not added in the container.

The test is set to fail if cqfd init succeeds **AND** if the file exists
in the container (cqfd run).

Thus, the test passes if cqfd init fails (or if the file is not in the
container), but, the test **MUST** fails if cqfd init fails.

This fixes the test by turning the logic to "if all needed conditions to
succeed the test are met, then the test passes, otherwise if any of the
conditions is unmet, then the test fails".