### PR TITLE
tests: reverse some test logic

### DIFF
--- a/tests/00-setup
+++ b/tests/00-setup
@@ -14,10 +14,10 @@ cd "$TDIR/" || exit 1
 # running 'cqfd init' should fail, as there's no proper config
 ################################################################################
 jtest_prepare "create a test skeleton in temporary directory"
-if "$cqfd" init; then
-	jtest_result fail
-else
+if ! "$cqfd" init; then
 	jtest_result pass
+else
+	jtest_result fail
 fi
 
 ################################################################################
@@ -25,10 +25,10 @@ fi
 ################################################################################
 jtest_prepare "cqfd init complains with an empty .cqfdrc"
 touch "$TDIR/.cqfdrc"
-if "$cqfd" init; then
-	jtest_result fail
-else
+if ! "$cqfd" init; then
 	jtest_result pass
+else
+	jtest_result fail
 fi
 
 ################################################################################
@@ -36,10 +36,10 @@ fi
 ################################################################################
 jtest_prepare "cqfd init complains with an incomplete .cqfdrc"
 echo '[project]' >"$TDIR/.cqfdrc"
-if "$cqfd" init; then
-	jtest_result fail
-else
+if ! "$cqfd" init; then
 	jtest_result pass
+else
+	jtest_result fail
 fi
 
 ################################################################################

--- a/tests/01-cqfd_init
+++ b/tests/01-cqfd_init
@@ -26,10 +26,10 @@ cqfdrc_old=$(mktemp)
 jtest_prepare "init with a nonexisting dockerfile shall fail"
 cp -f .cqfdrc "$cqfdrc_old"
 sed -i -e "s/\[build\]/[build]\ndistro='thisshouldfail'/" .cqfdrc
-if "$cqfd" init; then
-	jtest_result fail
-else
+if ! "$cqfd" init; then
 	jtest_result pass
+else
+	jtest_result fail
 fi
 
 ################################################################################

--- a/tests/03-cqfd_error
+++ b/tests/03-cqfd_error
@@ -9,10 +9,10 @@ cqfd="$TDIR"/.cqfd/cqfd
 # Running cqfd with an unknown argument shall fail
 ################################################################################
 jtest_prepare "run a bad cqfd command-line shall fail"
-if "$cqfd" invalid_arg_should_fail; then
-	jtest_result fail
-else
+if ! "$cqfd" invalid_arg_should_fail; then
 	jtest_result pass
+else
+	jtest_result fail
 fi
 
 ################################################################################
@@ -23,10 +23,10 @@ jtest_prepare "'cqfd run' with no config file shall fail"
 empty_dir=$(mktemp -d)
 pushd "$empty_dir" >/dev/null || exit 1
 
-if "$cqfd" run true; then
-	jtest_result fail
-else
+if ! "$cqfd" run true; then
 	jtest_result pass
+else
+	jtest_result fail
 fi
 
 # cleanup

--- a/tests/03-cqfd_help
+++ b/tests/03-cqfd_help
@@ -11,11 +11,11 @@ cqfd="$TDIR"/.cqfd/cqfd
 jtest_prepare "cqfd help shall exit normally"
 TEST=$(mktemp)
 
-if ! "$cqfd" help >"$TEST"; then
+if "$cqfd" help >"$TEST"; then
+	jtest_result pass
+else
 	jtest_result fail
 	rm -f "$TEST"
-else
-	jtest_result pass
 fi
 
 ################################################################################
@@ -31,10 +31,10 @@ for word in Usage Options Commands; do
 	fi
 done
 
-if [ "$missing" = "1" ]; then
-	jtest_result fail
-else
+if [ "$missing" != "1" ]; then
 	jtest_result pass
+else
+	jtest_result fail
 fi
 
 rm -f "$TEST"

--- a/tests/03-cqfd_version
+++ b/tests/03-cqfd_version
@@ -11,11 +11,11 @@ cqfd="$TDIR"/.cqfd/cqfd
 jtest_prepare "cqfd version shall exit normally"
 TEST=$(mktemp)
 
-if ! "$cqfd" version >"$TEST"; then
+if "$cqfd" version >"$TEST"; then
+	jtest_result pass
+else
 	jtest_result fail
 	rm -f "$TEST"
-else
-	jtest_result pass
 fi
 
 ################################################################################

--- a/tests/05-cqfd_init_alt_ext
+++ b/tests/05-cqfd_init_alt_ext
@@ -20,10 +20,10 @@ cqfd="$TDIR/${extdir}/cqfd/cqfd"
 # 'cqfd init' without local files should fail
 ################################################################################
 jtest_prepare "cqfd init without local files should fail"
-if "$cqfd" init; then
-	jtest_result fail
-else
+if ! "$cqfd" init; then
 	jtest_result pass
+else
+	jtest_result fail
 fi
 
 ################################################################################

--- a/tests/05-cqfd_init_custom_image
+++ b/tests/05-cqfd_init_custom_image
@@ -32,10 +32,10 @@ mkdir -p .cqfd/docker
 echo "FROM ubuntu:24.04" > .cqfd/docker/Dockerfile
 
 jtest_prepare "$cqfd_docker registry contains NO image named: $custom_image_1"
-if "$cqfd_docker" inspect "$custom_image_1" &>/dev/null; then
-	jtest_result fail
-else
+if ! "$cqfd_docker" inspect "$custom_image_1" &>/dev/null; then
 	jtest_result pass
+else
+	jtest_result fail
 fi
 
 jtest_prepare "cqfd init works using custom_img_name=$custom_image_1"

--- a/tests/05-cqfd_init_extra_env
+++ b/tests/05-cqfd_init_extra_env
@@ -17,10 +17,10 @@ cp -f .cqfd/docker/Dockerfile.init_extra_env .cqfd/docker/Dockerfile
 # 'cqfd init' without CQFD_EXTRA_BUILD_ARGS should fail
 ################################################################################
 jtest_prepare "cqfd init without using CQFD_EXTRA_BUILD_ARGS"
-if "$cqfd" init; then
-	jtest_result fail
-else
+if ! "$cqfd" init; then
 	jtest_result pass
+else
+	jtest_result fail
 fi
 
 ################################################################################

--- a/tests/05-cqfd_init_flavor
+++ b/tests/05-cqfd_init_flavor
@@ -30,10 +30,10 @@ fi
 ################################################################################
 flavorPart="${flavor:0:2}"
 jtest_prepare "cqfd init using part of '$flavor' flavor should fail"
-if "$cqfd" -b "$flavorPart" init; then
-	jtest_result fail
-else
+if ! "$cqfd" -b "$flavorPart" init; then
 	jtest_result pass
+else
+	jtest_result fail
 fi
 
 ################################################################################

--- a/tests/05-cqfd_run
+++ b/tests/05-cqfd_run
@@ -27,13 +27,13 @@ for i in 0 1; do
 	fi
 
 	# at the end of either test, $test_file is populated
-	if ! grep -qw "cqfd" $test_file; then
+	if grep -qw "cqfd" $test_file; then
+		jtest_result pass
+	else
 		jtest_log fatal "$test_file not present after test"
 		jtest_result fail
 		rm -f "$test_file"
 		continue
-	else
-		jtest_result pass
 	fi
 
 	rm -f "$test_file"
@@ -45,10 +45,10 @@ done
 jtest_prepare "Modifying the Dockerfile should require running 'cqfd init' again"
 dockerfile=.cqfd/docker/Dockerfile
 echo "RUN echo $RANDOM" >> $dockerfile
-if "$cqfd" run; then
-  jtest_result fail
-else
+if ! "$cqfd" run; then
   jtest_result pass
+else
+  jtest_result fail
 fi
 # restore Dockerfile
 sed -i '$d' $dockerfile

--- a/tests/05-cqfd_run_c
+++ b/tests/05-cqfd_run_c
@@ -36,13 +36,13 @@ test_step1() {
 	fi
 
 	# at the end of either test, $test_file is populated
-	if ! grep -qw "cqfd" "$test_file"; then
+	if grep -qw "cqfd" "$test_file"; then
+		jtest_result pass
+	else
 		jtest_log fatal "$test_file not present after test"
 		jtest_result fail
 		rm -f "$test_file"
 		return
-	else
-		jtest_result pass
 	fi
 }
     

--- a/tests/05-cqfd_run_c_flavor
+++ b/tests/05-cqfd_run_c_flavor
@@ -30,12 +30,12 @@ if ! grep -qw "target 'foo'" "$test_run_c_file"; then
 fi
 
 # at the end of either test, $test_file is populated
-if ! grep -qw "cqfd" "$test_file"; then
+if grep -qw "cqfd" "$test_file"; then
+	jtest_result pass
+else
 	jtest_log fatal "$test_file not present after test"
 	jtest_result fail
 	rm -f "$test_file"
-else
-	jtest_result pass
 fi
 
 rm -f $test_file

--- a/tests/05-cqfd_run_check_dependencies
+++ b/tests/05-cqfd_run_check_dependencies
@@ -20,10 +20,10 @@ cp -f .cqfd/docker/Dockerfile.missing_dependencies .cqfd/docker/Dockerfile
 # Missing all core dependencies for the launch script
 ################################################################################
 jtest_prepare "cqfd run fails when the Docker image lacks required commands"
-if "$cqfd" init && "$cqfd" run; then
-	jtest_result fail
-else
+if "$cqfd" init && ! "$cqfd" run; then
 	jtest_result pass
+else
+	jtest_result fail
 fi
 
 ################################################################################

--- a/tests/05-cqfd_run_command
+++ b/tests/05-cqfd_run_command
@@ -33,11 +33,11 @@ for i in 0 1; do
 	fi
 
 	# shellcheck disable=SC2181
-	if [ "$?" != 0 ] || [ ! -f "$test_file" ]; then
+	if [ "$?" -eq 0 ] && [ -f "$test_file" ]; then
+		jtest_result pass
+	else
 		jtest_log fatal "failed or test file not present after execution"
 		jtest_result fail
-	else
-		jtest_result pass
 	fi
 	rm -f "$test_file"
 done

--- a/tests/05-cqfd_run_config
+++ b/tests/05-cqfd_run_config
@@ -47,11 +47,11 @@ for i in 0 1 2 3; do
 	esac
 
 	# shellcheck disable=SC2181
-	if [ "$?" -ne 0 ] || [ ! -f "$test_file" ]; then
+	if [ "$?" -eq 0 ] && [ -f "$test_file" ]; then
+		jtest_result pass
+	else
 		jtest_log fatal "failed or test file not present after execution"
 		jtest_result fail
-	else
-		jtest_result pass
 	fi
 	rm -f "$test_file"
 done

--- a/tests/05-cqfd_run_flavor
+++ b/tests/05-cqfd_run_flavor
@@ -25,11 +25,11 @@ for i in 0 1; do
 	fi
 
 	# shellcheck disable=SC2181
-	if [ "$?" != 0 ] || [ ! -f "$test_file" ]; then
+	if [ "$?" -eq 0 ] && [ -f "$test_file" ]; then
+		jtest_result pass
+	else
 		jtest_log fatal "failed or test file not present after execution"
 		jtest_result fail
-	else
-		jtest_result pass
 	fi
 	rm -f "$test_file"
 done

--- a/tests/06-cqfd_release
+++ b/tests/06-cqfd_release
@@ -296,10 +296,10 @@ sed -i -e 's!^archive=.*$!archive=cqfd-$CTEST.tar.xz!' .cqfdrc
 sed -i -e 's!^files=.*$!files=".cq*rc Ma*"!' .cqfdrc
 
 # cqfd release must work witout error
-if ! "$cqfd" release; then
-	jtest_result fail
-else
+if "$cqfd" release; then
 	jtest_result pass
+else
+	jtest_result fail
 fi
 
 # the generated archive should contain our expanded globs


### PR DESCRIPTION
Most of the tests check for the success conditions, i.e, the test succeeds in the if statement (pass), and the test fails in the else statement (fail):

	if cqfd ...; then # or ! cqfd ...
		echo "yeah, test has passed!"
	else
		echo "oops, test has FAILED!"
	fi

However, some tests do not:

	if cqfd ...; then # or ! cqfd ...
		echo "oops, test has FAILED!"
	else
		echo "yeah, test has passed!"
	fi

This turns the test logic to "if all needed conditions to succeed the test are met, then the test passes, otherwise if any of the conditions is unmet, then the test fails".

It reverses some test logics so all the tests look similar and expect to pass in the if statement (and thus, fail in the else statement).