### PR TITLE
tests: reverse some test skip logic

### DIFF
--- a/tests/05-cqfd_run_extra_groups
+++ b/tests/05-cqfd_run_extra_groups
@@ -17,11 +17,10 @@ cp -f .cqfdrc "$cqfdrc_old"
 # 'cqfd run' should add extra_groups provided by an environment variable
 ################################################################################
 jtest_prepare "'cqfd run' should add extra_groups provided by an env variable"
-result=$(user_extra_groups="docker newgroup:12345" "$cqfd" run 'groups' | grep docker | grep newgroup)
-
 if [ "$USER" = "runner" ] || [ "$cqfd_docker" = "podman" ]; then
 	jtest_result skip
 else
+	result=$(user_extra_groups="docker newgroup:12345" "$cqfd" run 'groups' | grep docker | grep newgroup)
 	if [ -n "$result" ]; then
 		jtest_result pass
 	else
@@ -33,10 +32,9 @@ fi
 # 'cqfd run' should add extra_groups provided by the config
 ################################################################################
 jtest_prepare "'cqfd run' should add config's extra_groups to the local user"
-echo 'user_extra_groups="docker newgroup:12345"' >> .cqfdrc
-result=$("$cqfd" run 'groups' | grep docker | grep newgroup)
-
 if [ "$USER" != "runner" ] && [ "$cqfd_docker" != "podman" ]; then
+	echo 'user_extra_groups="docker newgroup:12345"' >> .cqfdrc
+	result=$("$cqfd" run 'groups' | grep docker | grep newgroup)
 	if [ -n "$result" ]; then
 		jtest_result pass
 	else

--- a/tests/05-cqfd_run_extra_groups
+++ b/tests/05-cqfd_run_extra_groups
@@ -32,7 +32,9 @@ fi
 # 'cqfd run' should add extra_groups provided by the config
 ################################################################################
 jtest_prepare "'cqfd run' should add config's extra_groups to the local user"
-if [ "$USER" != "runner" ] && [ "$cqfd_docker" != "podman" ]; then
+if [ "$USER" = "runner" ] || [ "$cqfd_docker" = "podman" ]; then
+	jtest_result skip
+else
 	echo 'user_extra_groups="docker newgroup:12345"' >> .cqfdrc
 	result=$("$cqfd" run 'groups' | grep docker | grep newgroup)
 	if [ -n "$result" ]; then
@@ -40,8 +42,6 @@ if [ "$USER" != "runner" ] && [ "$cqfd_docker" != "podman" ]; then
 	else
 		jtest_result fail
 	fi
-else
-	jtest_result skip
 fi
 
 mv -f "$cqfdrc_old" .cqfdrc

--- a/tests/08-cqfd_shell
+++ b/tests/08-cqfd_shell
@@ -102,12 +102,12 @@ else
 fi
 
 jtest_prepare "cqfd shell is usable as a shell interpreter in binaries"
-if command -v make 2>/dev/null; then
+if ! command -v make 2>/dev/null; then
+	jtest_result skip
+else
 	if PATH="$TDIR/.cqfd:$PATH"; make whereami 2>&1 | grep '^Ubuntu .* LTS$'; then
 		jtest_result pass
 	else
 		jtest_result fail
 	fi
-else
-	jtest_result skip
 fi

--- a/tests/09-cqfd-pts
+++ b/tests/09-cqfd-pts
@@ -15,14 +15,14 @@ sed -i -e "/\[build\]/,/^$/s/^command=.*$/command='tty || true'/" .cqfdrc
 "$cqfd" init
 
 jtest_prepare "cqfd without redirection should allocate a tty"
-if tty; then
+if ! tty; then
+	jtest_result skip
+else
 	if "$cqfd" | grep "/dev/pts/" ; then
 		jtest_result pass
 	else
 		jtest_result fail
 	fi
-else
-	jtest_result skip
 fi
 
 jtest_prepare "cqfd with stdin redirected to /dev/null should not allocate a pty"

--- a/tests/10-cqfd_doutofd
+++ b/tests/10-cqfd_doutofd
@@ -16,7 +16,9 @@ dockerfile_old=$(mktemp)
 cp -f .cqfd/docker/Dockerfile "$dockerfile_old"
 
 jtest_prepare "cqfd run docker using host docker daemon"
-if [ "$cqfd_docker" = "docker" ] && getent group docker | grep -q "$USER"; then
+if [ "$cqfd_docker" != "docker" ] || ! getent group docker | grep -q "$USER"; then
+	jtest_result skip
+else
 	cp -f .cqfd/docker/Dockerfile.doutofd .cqfd/docker/Dockerfile
 	sed -i -e "/\[build\]/,/^$/s,^command=.*$,command='docker run --rm -ti ubuntu:24.04 cat /etc/os-release'," .cqfdrc
 
@@ -25,8 +27,6 @@ if [ "$cqfd_docker" = "docker" ] && getent group docker | grep -q "$USER"; then
 	else
 		jtest_result fail
 	fi
-else
-	jtest_result skip
 fi
 
 mv -f "$cqfdrc_old" .cqfdrc


### PR DESCRIPTION
Some of the skip tests check for if the test has to be skipped first,
i.e, the test is skipped in the if statement (pass), and the test is
tested in the else statement (fail).

This reverses some skip test logics so all the tests look similar and
expect to be skipped in the if statement (and thus, to be tested in the
else statement).