### PR TITLE
cqfd: fix overriding HOME environment from docker_run_args

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -268,14 +268,9 @@ docker_run() {
 
 	# Set HOME variable for the $cqfd_user, except if it was explicitly set
 	# via CQFD_EXTRA_RUN_ARGS or docker_run_args
-	local home_env_var="HOME=$cqfd_user_home"
-	if echo "$CQFD_EXTRA_RUN_ARGS $build_docker_run_args" |
-	   grep -qE "(-e[[:blank:]]*|--env[[:blank:]]+)HOME="; then
-		home_env_var=""
-	fi
-
-	if [ "$home_env_var" ]; then
-		args+=(-e "$home_env_var")
+	if ! echo "$CQFD_EXTRA_RUN_ARGS $build_docker_run_args" |
+	     grep -qE "(-e[[:blank:]]*|--env[[:blank:]]+)HOME="; then
+		args+=(-e "HOME=$cqfd_user_home")
 	fi
 
 	if [ "$CQFD_NO_USER_SSH_CONFIG" != true ]; then

--- a/cqfd
+++ b/cqfd
@@ -266,13 +266,11 @@ docker_run() {
 		done
 	fi
 
-	# The user may set the CQFD_EXTRA_RUN_ARGS environment variables
-	# to pass custom run arguments to his development container.
-
-	# Set HOME variable for the $cqfd_user, except if it was
-	# explicitely set via CQFD_EXTRA_RUN_ARGS
+	# Set HOME variable for the $cqfd_user, except if it was explicitly set
+	# via CQFD_EXTRA_RUN_ARGS or docker_run_args
 	local home_env_var="HOME=$cqfd_user_home"
-	if echo "$CQFD_EXTRA_RUN_ARGS" | grep -qE "(-e[[:blank:]]*|--env[[:blank:]]+)HOME="; then
+	if echo "$CQFD_EXTRA_RUN_ARGS $build_docker_run_args" |
+	   grep -qE "(-e[[:blank:]]*|--env[[:blank:]]+)HOME="; then
 		home_env_var=""
 	fi
 

--- a/tests/05-cqfd_run_home_env_var
+++ b/tests/05-cqfd_run_home_env_var
@@ -10,6 +10,9 @@ cqfd_docker="${CQFD_DOCKER:-docker}"
 
 cd "$TDIR/" || exit 1
 
+cqfdrc_old=$(mktemp)
+cp -f .cqfdrc "$cqfdrc_old"
+
 ################################################################################
 # 'cqfd run' sets HOME environment variable for the local user
 ################################################################################
@@ -93,3 +96,67 @@ else
 		jtest_result fail
 	fi
 fi
+
+################################################################################
+# 'cqfd run' does not override HOME environment explicitly set via
+# docker_run_args
+################################################################################
+jtest_prepare "run doesn't override HOME env when set via docker_run_args"
+val1="value-$RANDOM"
+val2="value-$RANDOM"
+cat "$cqfdrc_old" - <<EOF >.cqfdrc
+docker_run_args="--env FOO=$val1 --env HOME=$val2"
+EOF
+
+# shellcheck disable=SC2016
+result=$("$cqfd" run 'echo -n $FOO $HOME' | grep value)
+
+if [ "$result" = "$val1 $val2" ]; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
+################################################################################
+# 'cqfd run' does not override HOME environment when it is the only entry in
+# docker_run_args
+################################################################################
+jtest_prepare "run doesn't override HOME env when the only entry in docker_run_args"
+val1="value-$RANDOM"
+cat "$cqfdrc_old" - <<EOF >.cqfdrc
+docker_run_args="--env HOME=$val1"
+EOF
+
+# shellcheck disable=SC2016
+result=$("$cqfd" run 'echo -n $FOO $HOME' | grep value)
+
+if [ "$result" = "$val1" ]; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
+################################################################################
+# 'cqfd run' does not confuse JAVA_HOME and the like with HOME when set via
+# docker_run_args
+################################################################################
+jtest_prepare "run doesn't confuse JAVA_HOME and the like with HOME"
+val1="value-$RANDOM"
+val2="value-$RANDOM"
+cat "$cqfdrc_old" - <<EOF >.cqfdrc
+docker_run_args="--env JAVA_HOME=$val1 --env HOME=$val2"
+EOF
+
+# shellcheck disable=SC2016
+result=$("$cqfd" run 'echo -n $JAVA_HOME $HOME' | grep value)
+
+if [ "$result" = "$val1 $val2" ]; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
+################################################################################
+# restore .cqfdrc
+################################################################################
+mv -f "$cqfdrc_old" .cqfdrc


### PR DESCRIPTION
cqfd provides two ways to set extra docker-run argument, either from the
environment via the variable CQFD_EXTRA_RUN_ARGS, or from the .cqfdrc
file via the build option docker_run_args.

cqfd checks if the HOME environment is overriden by the docker-run
option --env using the environment variable CQFD_EXTRA_RUN_ARGS.

However, cqfd does not checks if it is overriden by the build option
docker_run_args.

This adds the missing checks for overriding the HOME environment using
build option docker_run_args.