### PR TITLE
cqfd: optionize init command

### DIFF
--- a/bash-completion
+++ b/bash-completion
@@ -91,7 +91,7 @@ _cqfd() {
 		return
 	fi
 
-	local opts="-C -d -f -b -q -V --version -h --help"
+	local opts="-C -d -f -b -q --release -V --version -h --help"
 	if [[ "$cur" == -* ]]; then
 		COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
 		return

--- a/bash-completion
+++ b/bash-completion
@@ -91,7 +91,7 @@ _cqfd() {
 		return
 	fi
 
-	local opts="-C -d -f -b -q --release -V --version -h --help"
+	local opts="-C -d -f -b -q --reinit --release -V --version -h --help"
 	if [[ "$cur" == -* ]]; then
 		COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
 		return

--- a/cqfd
+++ b/cqfd
@@ -37,6 +37,7 @@ usage() {
 Usage: $PROGNAME [OPTIONS] [COMMAND] [COMMAND OPTIONS] [ARGUMENTS]
 
 Options:
+    --release            Release software.
     -f <file>            Use file as config file (default .cqfdrc).
     -d <directory>       Use directory as cqfd directory (default .cqfd).
     -C <directory>       Use the specified working directory.
@@ -655,6 +656,9 @@ while [ $# -gt 0 ]; do
 		;;
 	-q)
 		quiet=true
+		;;
+	--release)
+		has_to_release=true
 		;;
 	exec)
 		if [ "$#" -lt 2 ]; then

--- a/cqfd
+++ b/cqfd
@@ -37,6 +37,7 @@ usage() {
 Usage: $PROGNAME [OPTIONS] [COMMAND] [COMMAND OPTIONS] [ARGUMENTS]
 
 Options:
+    --reinit             Reinitialize build container.
     --release            Release software.
     -f <file>            Use file as config file (default .cqfdrc).
     -d <directory>       Use directory as cqfd directory (default .cqfd).
@@ -612,6 +613,7 @@ config_load() {
 }
 
 has_custom_cqfdrc=false
+has_to_init=false
 has_to_release=false
 has_alternate_command=false
 while [ $# -gt 0 ]; do
@@ -657,6 +659,9 @@ while [ $# -gt 0 ]; do
 	-q)
 		quiet=true
 		;;
+	--reinit)
+		has_to_init=true
+		;;
 	--release)
 		has_to_release=true
 		;;
@@ -667,6 +672,9 @@ while [ $# -gt 0 ]; do
 		shift
 		config_load "$flavor"
 		command_string="${*@Q}"
+		if $has_to_init; then
+			docker_build
+		fi
 		docker_run "$command_string"
 		exit
 		;;
@@ -704,6 +712,9 @@ while [ $# -gt 0 ]; do
 		fi
 		shift
 		config_load "$flavor"
+		if $has_to_init; then
+			docker_build
+		fi
 		command_string="$cqfd_shell"
 		if [ "$#" -gt 0 ]; then
 			command_string+=" ${*@Q}"
@@ -724,6 +735,10 @@ while [ $# -gt 0 ]; do
 done
 
 config_load "$flavor"
+
+if $has_to_init; then
+	docker_build
+fi
 
 if $has_alternate_command; then
 	build_cmd="$*"

--- a/tests/04-cqfd_init_context
+++ b/tests/04-cqfd_init_context
@@ -11,8 +11,7 @@ cd "$TDIR/" || exit 1
 # 'cqfd init' without context should fail the context
 ################################################################################
 jtest_prepare "cqfd init without using build_context"
-if "$cqfd" init &&
-   "$cqfd" run "! test -e /tmp/cqfdrc-build_context"; then
+if "$cqfd" --reinit run "! test -e /tmp/cqfdrc-build_context"; then
 	jtest_result pass
 else
 	jtest_result fail
@@ -29,8 +28,7 @@ cp -f cqfdrc-build_context .cqfdrc
 # 'cqfd init' with context changes the context
 ################################################################################
 jtest_prepare "cqfd init using build_context"
-if "$cqfd" init &&
-   "$cqfd" run "test -e /tmp/cqfdrc-build_context"; then
+if "$cqfd" --reinit run "test -e /tmp/cqfdrc-build_context"; then
 	jtest_result pass
 else
 	jtest_result fail

--- a/tests/05-cqfd_init_custom_image
+++ b/tests/05-cqfd_init_custom_image
@@ -39,7 +39,7 @@ else
 fi
 
 jtest_prepare "cqfd init works using custom_img_name=$custom_image_1"
-if "$cqfd" init && "$cqfd" run "true"; then
+if "$cqfd" --reinit run "true"; then
 	jtest_result pass
 else
 	jtest_result fail

--- a/tests/05-cqfd_init_extra_hosts
+++ b/tests/05-cqfd_init_extra_hosts
@@ -12,7 +12,7 @@ jtest_prepare "run cqfd with docker_build_args in config"
 echo "RUN cp /etc/hosts /tmp/hosts" >> "$TDIR/.cqfd/docker/Dockerfile"
 sed '/\[build\]/adocker_build_args="--add-host testhost:1.2.3.4"'\
     -i "$TDIR/.cqfdrc"
-output=$("$cqfd" init; "$cqfd" run cat /tmp/hosts; exit 0)
+output=$("$cqfd" --reinit run cat /tmp/hosts; exit 0)
 
 if [[ "$output" == *"1.2.3.4"*"testhost"* ]]; then
     jtest_result pass

--- a/tests/05-cqfd_init_flavor
+++ b/tests/05-cqfd_init_flavor
@@ -18,8 +18,7 @@ cp -f .cqfdrc "$cqfdrc_old"
 sed -i -e "s/\[foo\]/[foo]\ndistro='centos'/" .cqfdrc
 
 jtest_prepare "cqfd init using '$flavor' flavor"
-if "$cqfd" -b "$flavor" init &&
-   "$cqfd" -b "$flavor" run "grep '^NAME=' /etc/*release" | grep -q 'NAME="CentOS Linux"'; then
+if "$cqfd" -b "$flavor" --reinit run "grep '^NAME=' /etc/*release" | grep -q 'NAME="CentOS Linux"'; then
 	jtest_result pass
 else
 	jtest_result fail
@@ -42,8 +41,7 @@ fi
 mv -f "$cqfdrc_old" .cqfdrc
 
 jtest_prepare "cqfd init without flavor"
-if "$cqfd" init &&
-   "$cqfd" run "grep '^NAME=' /etc/*release" | grep -q 'NAME="Ubuntu"'; then
+if "$cqfd" --reinit run "grep '^NAME=' /etc/*release" | grep -q 'NAME="Ubuntu"'; then
 	jtest_result pass
 else
 	jtest_result fail

--- a/tests/05-cqfd_run_check_dependencies
+++ b/tests/05-cqfd_run_check_dependencies
@@ -20,7 +20,7 @@ cp -f .cqfd/docker/Dockerfile.missing_dependencies .cqfd/docker/Dockerfile
 # Missing all core dependencies for the launch script
 ################################################################################
 jtest_prepare "cqfd run fails when the Docker image lacks required commands"
-if "$cqfd" init && ! "$cqfd" run; then
+if ! "$cqfd" --reinit run; then
 	jtest_result pass
 else
 	jtest_result fail
@@ -38,7 +38,7 @@ jtest_prepare "cqfd run with satisfied command requirements, using su"
 if [ "$cqfd_docker" = "podman" ]; then
 	jtest_result skip
 else
-	if "$cqfd" init && "$cqfd" --verbose run true \
+	if "$cqfd" --reinit --verbose run true \
 		| awk -v rc=1 '/Using "su"/ { rc=0 } 1; END {exit rc}'; then
 		jtest_result pass
 	else
@@ -58,7 +58,7 @@ jtest_prepare "cqfd run with satisfied command requirements, using sudo"
 if [ "$cqfd_docker" = "podman" ]; then
 	jtest_result skip
 else
-	if "$cqfd" init && "$cqfd" --verbose run true \
+	if "$cqfd" --reinit --verbose run true \
 		| awk -v rc=1 '/Using "sudo"/ { rc=0 } 1; END {exit rc}'; then
 		jtest_result pass
 	else

--- a/tests/05-cqfd_run_su_or_sudo_backend
+++ b/tests/05-cqfd_run_su_or_sudo_backend
@@ -23,7 +23,7 @@ jtest_prepare "cqfd run with su -c"
 if [ "$cqfd_docker" = "podman" ]; then
 	jtest_result skip
 else
-	if "$cqfd" init && "$cqfd" --verbose run true \
+	if "$cqfd" --reinit --verbose run true \
 		| awk -v rc=1 '/Using "su" to execute command/ { rc=0 } 1; END {exit rc}'; then
 		jtest_result pass
 	else
@@ -43,7 +43,7 @@ jtest_prepare "cqfd run with su --session-command"
 if [ "$cqfd_docker" = "podman" ]; then
 	jtest_result skip
 else
-	if "$cqfd" init && "$cqfd" --verbose run true \
+	if "$cqfd" --reinit --verbose run true \
 		| awk -v rc=1 '/Using "su" to execute session command/ { rc=0 } 1; END {exit rc}'; then
 		jtest_result pass
 	else
@@ -64,7 +64,7 @@ jtest_prepare "cqfd run with sudo"
 if [ "$cqfd_docker" = "podman" ]; then
 	jtest_result skip
 else
-	if "$cqfd" init && "$cqfd" --verbose run true \
+	if "$cqfd" --reinit --verbose run true \
 		| awk -v rc=1 '/Using "sudo" to execute command/ { rc=0 } 1; END {exit rc}'; then
 		jtest_result pass
 	else

--- a/tests/10-cqfd_doutofd
+++ b/tests/10-cqfd_doutofd
@@ -22,7 +22,7 @@ else
 	cp -f .cqfd/docker/Dockerfile.doutofd .cqfd/docker/Dockerfile
 	sed -i -e "/\[build\]/,/^$/s,^command=.*$,command='docker run --rm -ti ubuntu:24.04 cat /etc/os-release'," .cqfdrc
 
-	if "$cqfd" init && CQFD_BIND_DOCKER_SOCK=true "$cqfd" | grep -qE 'PRETTY_NAME="Ubuntu 24.04(.[[:digit:]]+)? LTS"'; then
+	if CQFD_BIND_DOCKER_SOCK=true "$cqfd" --reinit | grep -qE 'PRETTY_NAME="Ubuntu 24.04(.[[:digit:]]+)? LTS"'; then
 		jtest_result pass
 	else
 		jtest_result fail


### PR DESCRIPTION
This adds the option --reinit that allows to cqfd init from an empty
command and the command run, and to cqfd init from the commands shell
and exec:

	cqfd [--reinit] [run] [command_string].
	cqfd [--reinit] shell [arguments]
	cqfd [--reinit] exec  program [arguments]