### PR TITLE
Fix "cqfd: add warning if run -c with build.command unset"

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -682,10 +682,6 @@ while [ $# -gt 0 ]; do
 				die "option -c requires arguments"
 			fi
 
-			if [ -z "$build_cmd" ]; then
-				warn "$cqfdrc: Missing or empty build.command property"
-			fi
-
 			shift
 			break
 		fi
@@ -720,6 +716,10 @@ while [ $# -gt 0 ]; do
 done
 
 config_load "$flavor"
+
+if ! $has_alternate_command && [ -n "$*" ] && [ -z "$build_cmd" ]; then
+	warn "$cqfdrc: Missing or empty build.command property"
+fi
 
 if $has_alternate_command; then
 	build_cmd="$*"

--- a/tests/03-cqfdrc_error
+++ b/tests/03-cqfdrc_error
@@ -77,6 +77,16 @@ else
 	jtest_result fail
 fi
 
+echo "command=true" >>.cqfdrc
+
+jtest_prepare "cqfdrc succeeds if command property set in build section using run -c"
+if "$cqfd" run -c true 2>&1 | grep "cqfd: warning: .cqfdrc: Missing or empty build.command property";
+   test "${PIPESTATUS[0]}" -eq 0 -a "${PIPESTATUS[1]}" -ne 0; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
 cp -f "$cqfdrc_old" .cqfdrc
 echo "foo	=bar" >>.cqfdrc
 


### PR DESCRIPTION
The .cqfdrc file is not loaded and the warning below always poutputs even if command= is set to an non-empty string:

	$ cat .cqfdrc
	[project]
	name=test
	org=test
	[build]
	command=true

	$ cqfd run -c true
	cqfd: warning: .cqfdrc: Missing or empty build.command property

This fixes commit 6dd7415ac41376aafc0581237ebbd1647d420bcb.