### PR TITLE
cqfd: launcher: use option --entrypoint

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -311,9 +311,10 @@ docker_run() {
 	make_launcher "$tmp_launcher"
 	chmod 0755 "$tmp_launcher"
 	args+=(--volume "$tmp_launcher:/bin/cqfd_launch")
+	args+=(--entrypoint "/bin/cqfd_launch")
 
 	# Set positional arguments
-	args+=("$docker_img_name" cqfd_launch "$1")
+	args+=("$docker_img_name" "$1")
 
 	# Run command
 	debug executing: "$cqfd_docker" run "${args[@]}"

--- a/cqfd
+++ b/cqfd
@@ -305,13 +305,13 @@ docker_run() {
 
 	args+=(--volume "$cqfd_project_dir:$cqfd_project_dir")
 
-	# Create and bind mount the launcher script
-	tmp_launcher=$(mktemp /tmp/cqfd_launcher.XXXXXX)
-	trap 'rm -f "$tmp_launcher"' EXIT
-	make_launcher "$tmp_launcher"
-	chmod 0755 "$tmp_launcher"
-	args+=(--volume "$tmp_launcher:/bin/cqfd_launch")
-	args+=(--entrypoint "/bin/cqfd_launch")
+	# Create and bind mount the entrypoint
+	tmp_entrypoint=$(mktemp /tmp/cqfd-entrypoint.XXXXXX)
+	trap 'rm -f "$tmp_entrypoint"' EXIT
+	make_entrypoint "$tmp_entrypoint"
+	chmod 0755 "$tmp_entrypoint"
+	args+=(--volume "$tmp_entrypoint:/bin/cqfd-entrypoint")
+	args+=(--entrypoint "/bin/cqfd-entrypoint")
 
 	# Set positional arguments
 	args+=("$docker_img_name" "$1")
@@ -401,9 +401,9 @@ make_archive() {
 	esac
 }
 
-## make_launcher - generate in-container launcher script
-# $1: the path to the launcher script
-make_launcher() {
+# make_entrypoint - generate in-container entrypoint
+# $1: the path to the entrypoint
+make_entrypoint() {
 	cat >"$1" <<EOF
 #!/bin/sh
 # create container user to match expected environment

--- a/tests/05-cqfd_run_dockerfile
+++ b/tests/05-cqfd_run_dockerfile
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# validate the behavior of run with Dockerfile
+
+. "$(dirname "$0")"/jtest.inc "$1"
+cqfd="$TDIR/.cqfd/cqfd"
+
+cd "$TDIR/" || exit 1
+
+# backup Dockerfile
+cp -f .cqfd/docker/Dockerfile .cqfd/docker/Dockerfile.orig
+
+jtest_prepare "cqfd run using a Dockerfile with entrypoint should success"
+cat <<EOF >>.cqfd/docker/Dockerfile
+ENTRYPOINT ["false"]
+EOF
+if "$cqfd" init && "$cqfd" run; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
+# restore Dockerfile
+mv -f .cqfd/docker/Dockerfile.orig .cqfd/docker/Dockerfile
+"$cqfd" init


### PR DESCRIPTION
cqfd does not run its launcher script if the image used has its own
entrypoint set in the Dockerfile.

This sets the launcher as the container ENTRYPOINT, i.e. it runs it as
the container executable and it overwrites the default ENTRYPOINT of the
image if set.