### PR TITLE
cqfd: add -w option to set working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ In some conditions you may want to use alternate cqfd filenames and / or an
 external working directory. These options can be used to control the cqfd
 configuration files:
 
-The working directory can be changed using the `-C` option:
+The current working directory can be changed using the `-C` option:
 
     $ cqfd -C external/directory
 
@@ -335,10 +335,15 @@ An alternate cqfdrc file can be specified with the `-f` option:
 
     $ cqfd -f cqfdrc_alt
 
+An alternate working directory can be specified with the `-w` option:
+
+    $ cqfd -w ..
+
 These options can be combined together:
 
-    $ cqfd -C external/directory -d cqfd_alt -f cqfdrc_alt
+    $ cqfd -C external/directory -w .. -d cqfd_alt -f cqfdrc_alt
     $ # cqfd will use:
+    $ #  - cqfd working directory: external
     $ #  - cqfd directory: external/directory/cqfd_alt
     $ #  - cqfdrc file: external/directory/cqfdrc_alt
 

--- a/bash-completion
+++ b/bash-completion
@@ -28,7 +28,7 @@ _cqfd() {
 	_init_completion || return
 
 	case $prev in
-	-C|-d|-f)
+	-C|-w|-d|-f)
 		_filedir
 		return
 		;;
@@ -90,7 +90,7 @@ _cqfd() {
 		return
 	fi
 
-	local opts="-C -d -f -b -q --release -V --version -h --help"
+	local opts="-C -w -d -f -b -q --release -V --version -h --help"
 	if [[ "$cur" == -* ]]; then
 		COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
 		return

--- a/cqfd
+++ b/cqfd
@@ -40,7 +40,9 @@ Options:
     --release            Release software.
     -f <file>            Use file as config file (default .cqfdrc).
     -d <directory>       Use directory as cqfd directory (default .cqfd).
-    -C <directory>       Use the specified working directory.
+    -w <directory>       Use directory as working directory (default parent of
+                         .cqfd).
+    -C <directory>       Change to the specified working directory.
     -b <flavor_name>     Target a specific build flavor.
     -q                   Turn on quiet mode.
     -v or --version      Show version.
@@ -221,7 +223,6 @@ docker_run() {
 
 	if [ -n "$HOME" ]; then
 		cqfd_user_home="$(cd "$HOME"; pwd)"
-		cqfd_user_cwd="$(pwd)"
 	fi
 
 	# Get the docker gid if the group exists
@@ -303,7 +304,14 @@ docker_run() {
 		args+=(--volume /var/run/docker.sock:/var/run/docker.sock)
 	fi
 
-	args+=(--volume "$cqfd_project_dir:$cqfd_project_dir")
+	# Bind mount the project directory
+	local workdir
+	if ! workdir="$(realpath "$build_workdir")" ||
+	   [ ! -d "$workdir" ]; then
+		die "$build_workdir: Missing or not a directory!"
+	fi
+	cqfd_user_cwd="$workdir"
+	args+=(--volume "$cqfd_user_cwd:$cqfd_user_cwd")
 
 	# Create and bind mount the entrypoint
 	tmp_entrypoint=$(mktemp /tmp/cqfd-entrypoint.XXXXXX)
@@ -517,13 +525,25 @@ locate_project_dir() {
 ## load_config() - load build settings from cqfdrc
 # $1: optional "flavor" of the build, is a suffix of command
 load_config() {
-	if ! cqfd_project_dir=$(locate_project_dir); then
-		die ".cqfd directory not found in directory tree"
+	# get the project directory
+	local project_dir
+	if ! project_dir=$(locate_project_dir); then
+		die ".cqfd: Missing project directory!"
+	fi
+
+	# unless using '-w other_workdir', use current working directory
+	if ! $has_custom_workdir; then
+		workdir="$PWD"
+	fi
+	# make an absolute path and check if it is a directory
+	if ! workdir="$(realpath "$workdir")" || \
+	   [ ! -d "$workdir" ]; then
+		die ".cqfd: Missing or not a directory!"
 	fi
 
 	# unless using '-f other_cqfdrc', use base directory located above
 	if ! $has_custom_cqfdrc; then
-		local cqfdrc_dir="$cqfd_project_dir/"
+		local cqfdrc_dir="$project_dir/"
 	fi
 
 	if [ ! -f "$cqfdrc_dir$cqfdrc" ]; then
@@ -587,6 +607,8 @@ load_config() {
 	fi
 
 	# shellcheck disable=SC2154
+	build_workdir="$workdir"
+	# shellcheck disable=SC2154
 	build_command="$command"
 	# shellcheck disable=SC2154
 	build_docker_build_args="$docker_build_args"
@@ -605,7 +627,7 @@ load_config() {
 	# shellcheck disable=SC2154
 	release_tar_opts="$tar_options"
 
-	dockerfile="$cqfd_project_dir/$cqfddir/${build_distro:-docker}/Dockerfile"
+	dockerfile="$project_dir/$cqfddir/${build_distro:-docker}/Dockerfile"
 	if [ ! -f "$dockerfile" ]; then
 		die "$dockerfile not found"
 	fi
@@ -624,6 +646,7 @@ load_config() {
 	fi
 }
 
+has_custom_workdir=false
 has_custom_cqfdrc=false
 has_to_release=false
 has_alternate_command=false
@@ -653,6 +676,11 @@ while [ $# -gt 0 ]; do
 	-b)
 		shift
 		flavor="$1"
+		;;
+	-w)
+		shift
+		has_custom_workdir=true
+		workdir="$1"
 		;;
 	-d)
 		shift

--- a/cqfd.1.adoc
+++ b/cqfd.1.adoc
@@ -62,8 +62,11 @@ Command options for run:
 *-d DIR*::
 	Use directory as cqfd directory (default _.cqfd_).
 
+*-w DIR*::
+	Use directory as working directory (default parent of _.cqfd_).
+
 *-C DIR*::
-	Use the specified working directory.
+	Change to the specified working directory.
 
 *-b STRING*::
 	Target a specific build flavor.

--- a/tests/05-cqfd_run_alt_ext
+++ b/tests/05-cqfd_run_alt_ext
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# validate the behavior of run with working directory
+
+set -o pipefail
+
+. "$(dirname "$0")"/jtest.inc "$1"
+
+cd "$TDIR/" || exit 1
+
+################################################################################
+# First, move every local cqfd files into an external directory and use
+# alternate filenames
+################################################################################
+workdir="workingdir"
+mkdir -p "$workdir"
+mv .cqfd "$workdir/.cqfd"
+mv .cqfdrc "$workdir/.cqfdrc"
+cqfd="$TDIR/$workdir/.cqfd/cqfd"
+cd "$workdir" || exit 1
+
+################################################################################
+# 'cqfd run' using nonexistent working directory should fail
+################################################################################
+jtest_prepare "cqfd run using inexistant working directory should fail"
+if ! "$cqfd" -w "nonexistentdir" run; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
+################################################################################
+# 'cqfd run' using default working directory should work
+################################################################################
+jtest_prepare "cqfd run using default working directory should work"
+if "$cqfd" run "stat -c '%u' ." | grep -q "$UID" && \
+   "$cqfd" run "stat -c '%u' .." | grep -q "0"; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
+################################################################################
+# 'cqfd run' using alternate working directory should work
+################################################################################
+jtest_prepare "cqfd run using working directory should work"
+if "$cqfd" -w ".." run "stat -c '%u' ." | grep -q "$UID" && \
+   "$cqfd" -w ".." run "stat -c '%u' .." | grep -q "0"; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
+################################################################################
+# restore local cqfd files
+################################################################################
+cd "$OLDPWD" || exit 1
+mv "$workdir/.cqfdrc" .cqfdrc
+mv "$workdir/.cqfd" .cqfd
+rmdir -p "$workdir"


### PR DESCRIPTION
cqfd bind-mounts the parent directory of .cqfd by default. It may be useful to map another directory in certain circumstances.

This adds the option -w to set the working directory to bind-mount the specified directory instead of the parent of the .cqfd directory.