### PR TITLE
tests: fix uncleaned temporary directory

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -11,7 +11,7 @@ tests: CQFD_BIND_DOCKER_SOCK =
 tests: CQFD_DOCKER_GID =
 tests: CQFD_SHELL =
 tests:
-	@$(eval TDIR=$(shell mktemp -d))
+	@$(eval TDIR=$(shell mktemp -d /tmp/cqfd-test.XXXXXX))
 	@for f in [0-9][0-9]*; do \
 		if [ -x "$$f" ]; then \
 			./$$f $(TDIR); \
@@ -26,7 +26,7 @@ tests:
 			failed=1; \
 		fi; \
 	fi; \
-	if echo $(TDIR) | grep -q "/tmp/tmp\.[0-9a-zA-Z]\+"; then \
+	if echo $(TDIR) | grep -q "/tmp/cqfd-test\.[0-9a-zA-Z]{6,6}"; then \
 		rm -rf $(TDIR); \
 	fi; \
 	if [ "$$failed" = "1" ]; then \

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -26,7 +26,7 @@ tests:
 			failed=1; \
 		fi; \
 	fi; \
-	if echo $(TDIR) | grep -q "/tmp/tmp\.[a-zA-Z]"; then \
+	if echo $(TDIR) | grep -q "/tmp/tmp\.[0-9a-zA-Z]\+"; then \
 		rm -rf $(TDIR); \
 	fi; \
 	if [ "$$failed" = "1" ]; then \


### PR DESCRIPTION
mktemp(1) replaces the TEMPLATE (/tmp/tmp.XXXXXX) by letters **AND**
digits, even if its man-page does not mention it clearly.

As a consequence, the test directory is not be removed if it starts by a
digit.

This fixes the uncleaned directory by adding the missing digit range to
the regex pattern.

Fixes:

	$ make test
	(...)
	$ ls -ld /tmp/cqfd-test.*
	drwxrwxr-x 3 gportay gportay 4096 Aug  9 17:13 /tmp/tmp.9gbPXP

Note: Additionally, it enforces the regular expression by adding the
repetition operator +.

From grep(1):

	Repetition
	
	A regular expression may be followed by one of several
	repetition operators:
	
	?      The preceding item is optional and matched at most once.
	*      The preceding item will be matched zero or more times.
	+      The preceding item will be matched one or more times.
	{n}    The preceding item is matched exactly n times.
	{n,}   The preceding item is matched n or more times.
	{,m}   The preceding item is matched at most m times.  This is a
	       GNU extension.
	{n,m}  The preceding item is matched at least n times, but not
	       more than m times.