### PR TITLE
tests: more nitpicks

### DIFF
--- a/tests/00-setup
+++ b/tests/00-setup
@@ -6,7 +6,7 @@
 mkdir -p "$TDIR/.cqfd/docker"
 cp -a ../cqfd "$TDIR/.cqfd/"
 cp -a test_data/. "$TDIR/."
-cqfd="$TDIR"/.cqfd/cqfd
+cqfd="$TDIR/.cqfd/cqfd"
 
 cd "$TDIR/" || exit 1
 

--- a/tests/01-cqfd_init
+++ b/tests/01-cqfd_init
@@ -5,7 +5,7 @@
 set -o pipefail
 
 . "$(dirname "$0")"/jtest.inc "$1"
-cqfd="$TDIR"/.cqfd/cqfd
+cqfd="$TDIR/.cqfd/cqfd"
 
 cd "$TDIR/" || exit 1
 

--- a/tests/03-cqfd_error
+++ b/tests/03-cqfd_error
@@ -3,7 +3,7 @@
 # validate the behavior with erroneous usages
 
 . "$(dirname "$0")"/jtest.inc "$1"
-cqfd="$TDIR"/.cqfd/cqfd
+cqfd="$TDIR/.cqfd/cqfd"
 
 ################################################################################
 # Running cqfd with an empty argument shall fail

--- a/tests/03-cqfd_help
+++ b/tests/03-cqfd_help
@@ -3,7 +3,7 @@
 # validate the behavior of help command
 
 . "$(dirname "$0")"/jtest.inc "$1"
-cqfd="$TDIR"/.cqfd/cqfd
+cqfd="$TDIR/.cqfd/cqfd"
 
 ################################################################################
 # 'cqfd help' shall be an accepted command

--- a/tests/03-cqfd_version
+++ b/tests/03-cqfd_version
@@ -3,7 +3,7 @@
 # validate the behavior of version command
 
 . "$(dirname "$0")"/jtest.inc "$1"
-cqfd="$TDIR"/.cqfd/cqfd
+cqfd="$TDIR/.cqfd/cqfd"
 
 ################################################################################
 # 'cqfd version' shall be an accepted command

--- a/tests/03-cqfdrc_error
+++ b/tests/03-cqfdrc_error
@@ -42,7 +42,7 @@ else
 	jtest_result fail
 fi
 
-echo "org=test" >>.cqfdrc
+echo "org=cqfd" >>.cqfdrc
 
 jtest_prepare "cqfdrc fails if no build section"
 if "$cqfd" 2>&1 | grep "cqfd: fatal: .cqfdrc: Missing build section!";

--- a/tests/05-cqfd_init_custom_image
+++ b/tests/05-cqfd_init_custom_image
@@ -9,7 +9,7 @@ cqfd_docker="${CQFD_DOCKER:-docker}"
 # create a temporary directory
 TEST_DIR=$(mktemp -d -t cqfd-test-XXXXXX)
 
-cd "$TEST_DIR"/ || exit 1
+cd "$TEST_DIR/" || exit 1
 
 ################################################################################
 # 'cqfd init' with custom_img_name

--- a/tests/05-cqfd_run_config
+++ b/tests/05-cqfd_run_config
@@ -12,7 +12,6 @@ cd "$TDIR/" || exit 1
 # cp the default conf and replace the original with a fake one
 mkdir -p "$confdir"
 mv .cqfdrc "$confdir"/mycqfdrc
-touch .cqfdrc
 
 # First pass: run with non default config file
 # Second pass: run with non default config file and bash cmd

--- a/tests/06-cqfd_release
+++ b/tests/06-cqfd_release
@@ -67,7 +67,7 @@ for f in $rel_files; do
 	fi
 done
 jtest_result "$result"
-sed -i -e '$ s!^tar_transform.*$!!' .cqfdrc
+sed -i -e '$ s!^tar_transform=.*$!!' .cqfdrc
 rm -f cqfd-test.tar.xz
 
 # now use tar_transform=yes
@@ -81,7 +81,7 @@ for f in $rel_files; do
 	fi
 done
 jtest_result "$result"
-sed -i -e '$ s!^tar_transform.*$!!' .cqfdrc
+sed -i -e '$ s!^tar_transform=.*$!!' .cqfdrc
 rm -f cqfd-test.tar.xz
 
 ################################################################################
@@ -110,7 +110,7 @@ jtest_result "$result"
 
 # revert the changes in .cqfdrc file
 rm -f link.txt
-sed -i '/tar_options/d' .cqfdrc
+sed -i '/tar_options=/d' .cqfdrc
 sed -i '/files=/d' .cqfdrc
 echo "files=\"$rel_files\"" >>.cqfdrc
 

--- a/tests/06-cqfd_release
+++ b/tests/06-cqfd_release
@@ -134,7 +134,7 @@ rm -f "cqfd-$d3-foobar.tar.xz"
 
 jtest_prepare "build.archive can template filenames (git short hash of last commit)"
 # shellcheck disable=SC2016
-sed -i -e '$ s!^archive=.*!archive=cqfd-%Gh-$CTEST.tar.xz!' .cqfdrc
+sed -i -e '$ s!^archive=.*$!archive=cqfd-%Gh-$CTEST.tar.xz!' .cqfdrc
 # shellcheck disable=SC2010
 if "$cqfd" release &&
    ls -1 cqfd-*-foobar.tar.xz | grep -q "^cqfd-[[:xdigit:]]\{4,40\}-foobar.tar.xz$" &&
@@ -147,7 +147,7 @@ rm -f cqfd-*-foobar.tar.xz
 
 jtest_prepare "build.archive can template filenames (git long hash of last commit)"
 # shellcheck disable=SC2016
-sed -i -e '$ s!^archive=.*!archive=cqfd-%GH-$CTEST.tar.xz!' .cqfdrc
+sed -i -e '$ s!^archive=.*$!archive=cqfd-%GH-$CTEST.tar.xz!' .cqfdrc
 # shellcheck disable=SC2010
 if "$cqfd" release &&
    ls -1 cqfd-*-foobar.tar.xz | grep -q "^cqfd-[[:xdigit:]]\{40\}-foobar.tar.xz$" &&
@@ -160,7 +160,7 @@ rm -f cqfd-*-foobar.tar.xz
 
 jtest_prepare "build.archive can template filenames (Unix timestamp)"
 # shellcheck disable=SC2016
-sed -i -e '$ s!^archive=.*!archive=cqfd-%Du-$CTEST.tar.xz!' .cqfdrc
+sed -i -e '$ s!^archive=.*$!archive=cqfd-%Du-$CTEST.tar.xz!' .cqfdrc
 # shellcheck disable=SC2010
 if "$cqfd" release &&
    ls -1 cqfd-*-foobar.tar.xz | grep -q "^cqfd-[[:digit:]]\{1,20\}-foobar.tar.xz$" &&
@@ -173,7 +173,7 @@ rm -f cqfd-*-foobar.tar.xz
 
 jtest_prepare "build.archive can template filenames (current cqfd flavor name unset)"
 # shellcheck disable=SC2016
-sed -i -e '$ s!^archive=.*!archive=cqfd-%Cf-$CTEST.tar.xz!' .cqfdrc
+sed -i -e '$ s!^archive=.*$!archive=cqfd-%Cf-$CTEST.tar.xz!' .cqfdrc
 if "$cqfd" release && tar tf cqfd--foobar.tar.xz &>/dev/null; then
 	jtest_result pass
 else
@@ -191,7 +191,7 @@ rm -f cqfd-foo.tar.xz
 
 jtest_prepare "build.archive can template filenames (value of the project.org configuration key)"
 # shellcheck disable=SC2016
-sed -i -e '$ s!^archive=.*!archive=cqfd-%Po-$CTEST.tar.xz!' .cqfdrc
+sed -i -e '$ s!^archive=.*$!archive=cqfd-%Po-$CTEST.tar.xz!' .cqfdrc
 if "$cqfd" release && tar tf cqfd-cqfd-foobar.tar.xz &>/dev/null; then
 	jtest_result pass
 else
@@ -201,7 +201,7 @@ rm -f cqfd-cqfd-foobar.tar.xz
 
 jtest_prepare "build.archive can template filenames (value of the project.name configuration key)"
 # shellcheck disable=SC2016
-sed -i -e '$ s!^archive=.*!archive=cqfd-%Pn-$CTEST.tar.xz!' .cqfdrc
+sed -i -e '$ s!^archive=.*$!archive=cqfd-%Pn-$CTEST.tar.xz!' .cqfdrc
 if "$cqfd" release && tar tf cqfd-test-foobar.tar.xz &>/dev/null; then
 	jtest_result pass
 else
@@ -224,7 +224,7 @@ rm -f cqfd-%-foobar.tar.xz
 ################################################################################
 jtest_prepare "build.archive can make a .tar.gz archive"
 # shellcheck disable=SC2016
-sed -i -e '$ s!^archive=.*xz!archive=cqfd-$CTEST.tar.gz!' .cqfdrc
+sed -i -e '$ s!^archive=.*xz$!archive=cqfd-$CTEST.tar.gz!' .cqfdrc
 "$cqfd" release
 if tar ztf "cqfd-$CTEST.tar.gz" &>/dev/null; then
 	jtest_result pass
@@ -238,7 +238,7 @@ rm -f "cqfd-$CTEST.tar.gz"
 ################################################################################
 jtest_prepare "build.archive can make a .zip archive"
 # shellcheck disable=SC2016
-sed -i -e '$ s!^archive=.*gz!archive=cqfd-$CTEST.zip!' .cqfdrc
+sed -i -e '$ s!^archive=.*gz$!archive=cqfd-$CTEST.zip!' .cqfdrc
 "$cqfd" release
 if unzip -l "cqfd-$CTEST.zip" &>/dev/null; then
 	jtest_result pass


### PR DESCRIPTION
This PR fixes two nitpicks:

The first nitpick double-quotes the whole string including the variable name `$TDIR`, as the most of test files:

``` diff
-cqfd="$TDIR"/.cqfd/cqfd
+cqfd="$TDIR/.cqfd/cqfd"
```

The second nitpick updates the project.org to `cqfd' for [tests/03-cqfdrc_error] so every built containers use the exact same tag, and thus, every built containers are similar and easily remarkable:

	cqfd_<user>_cqfd_test_<hash>[_<distro>]
