### PR TITLE
tests: save retesting by 40 seconds

### DIFF
--- a/tests/test_data/.cqfd/docker/Dockerfile.init_extra_env
+++ b/tests/test_data/.cqfd/docker/Dockerfile.init_extra_env
@@ -1,8 +1,4 @@
 FROM ubuntu:24.04
 
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update && apt-get install -y --no-install-recommends make
-
 ARG FOO
 RUN touch ${FOO} 2>/dev/null


### PR DESCRIPTION
The test "cqfd init using CQFD_EXTRA_BUILD_ARGS" rebuilds the image without using the cache, causing to the (re)installation of the package make that is not necessary.

It takes around 40 seconds:

	$ make test
	(...)
	[14:25:52|info] result: cqfd init without using CQFD_EXTRA_BUILD_ARGS: PASS
	[14:25:52|notice] preparing "cqfd init using CQFD_EXTRA_BUILD_ARGS"
	[+] Building 39.7s (7/7) FINISHED                                                                                                                                        docker:default
	 => [internal] load build definition from Dockerfile                                                                                                                               0.0s
	 => => transferring dockerfile: 202B                                                                                                                                               0.0s
	 => [internal] load metadata for docker.io/library/ubuntu:24.04                                                                                                                    0.0s
	 => [internal] load .dockerignore                                                                                                                                                  0.0s
	 => => transferring context: 2B                                                                                                                                                    0.0s
	 => CACHED [1/3] FROM docker.io/library/ubuntu:24.04                                                                                                                               0.0s
	 => [2/3] RUN apt-get update && apt-get install -y --no-install-recommends make                                                                                                   39.2s
	 => [3/3] RUN touch foo 2>/dev/null                                                                                                                                                0.2s
	 => exporting to image                                                                                                                                                             0.2s
	 => => exporting layers                                                                                                                                                            0.2s
	 => => writing image sha256:0ba591348d518e8332329c836880c34aaa8e6df12b18c5733892da8c885d37db                                                                                       0.0s
	 => => naming to docker.io/library/cqfd_gportay_cqfd_test_05ca8e0                                                                                                                  0.0s
	[14:26:31|info] result: cqfd init using CQFD_EXTRA_BUILD_ARGS: PASS
	(...)
	real	1m51.220s
	user	0m8.826s
	sys	0m11.546s

This removes the installation of the unused package make to save retesting by most that 33%.

	$ make test
	(...)
	[14:32:28|info] result: cqfd init without using CQFD_EXTRA_BUILD_ARGS: PASS
	[14:32:28|notice] preparing "cqfd init using CQFD_EXTRA_BUILD_ARGS"
	[+] Building 0.3s (6/6) FINISHED                                                                                                                                         docker:default
	 => [internal] load build definition from Dockerfile                                                                                                                               0.0s
	 => => transferring dockerfile: 93B                                                                                                                                                0.0s
	 => [internal] load metadata for docker.io/library/ubuntu:24.04                                                                                                                    0.0s
	 => [internal] load .dockerignore                                                                                                                                                  0.0s
	 => => transferring context: 2B                                                                                                                                                    0.0s
	 => CACHED [1/2] FROM docker.io/library/ubuntu:24.04                                                                                                                               0.0s
	 => [2/2] RUN touch foo 2>/dev/null                                                                                                                                                0.2s
	 => exporting to image                                                                                                                                                             0.0s
	 => => exporting layers                                                                                                                                                            0.0s
	 => => writing image sha256:9715c3d9dd4afa5ae66bbea32de03f3fb5e30088b12b86fc073d5c3d970882dd                                                                                       0.0s
	 => => naming to docker.io/library/cqfd_gportay_cqfd_test_dd19a3e                                                                                                                  0.0s
	[14:32:28|info] result: cqfd init using CQFD_EXTRA_BUILD_ARGS: PASS
	(...)
	real	1m9.528s
	user	0m8.664s
	sys	0m10.997s