### PR TITLE
cqfd: buildx: prints raw build process on verbose

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -639,6 +639,7 @@ while [ $# -gt 0 ]; do
 		;;
 	--verbose)
 		export CQFD_DEBUG=true
+		export BUILDKIT_PROGRESS=plain
 		;;
 	init)
 		load_config "$flavor"


### PR DESCRIPTION
This prints the raw build progress in a plaintext format if --verbose by using the BUILDKIT_PROGRESS environment variable

[1]: https://docs.docker.com/reference/cli/docker/buildx/build/#progress