### PR TITLE
cqfd: allow relative and absolute path with -d option

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -499,7 +499,7 @@ EOF
 }
 
 ## locate_project_dir() - locate directory with .cqfd upwards
-# stdout: the path to the .cqfd directory
+# stdout: the path to the .cqfd parent directory
 locate_project_dir() {
 	local search_dir="$PWD"
 

--- a/cqfd
+++ b/cqfd
@@ -506,7 +506,7 @@ locate_project_dir() {
 	while [ "$search_dir" != "/" ]; do
 		if [ -d "$search_dir"/"$cqfddir" ]; then
 			realpath "$search_dir"
-			return 0
+			return
 		fi
 		search_dir="$(readlink -f "$search_dir"/..)"
 	done

--- a/cqfd
+++ b/cqfd
@@ -336,7 +336,7 @@ make_archive() {
 
 	eval "files=($release_files)"
 	if [ -z "${files[*]}" ]; then
-		die "No files to archive, check files in $cqfdrc"
+		die "No files to archive, check files in .cqfdrc"
 	fi
 
 	for file in "${files[@]}"; do
@@ -523,15 +523,15 @@ load_config() {
 
 	# unless using '-f other_cqfdrc', use base directory located above
 	if ! $has_custom_cqfdrc; then
-		local cqfdrc_dir="$cqfd_project_dir/"
+		cqfdrc="$cqfd_project_dir/$cqfdrc"
 	fi
 
-	if [ ! -f "$cqfdrc_dir$cqfdrc" ]; then
-		die "Unable to find $cqfdrc_dir$cqfdrc - create it or pick one using 'cqfd -f'"
+	if [ ! -f "$cqfdrc" ]; then
+		die "Unable to find .cqfdrc - create it or pick one using 'cqfd -f'"
 	fi
 
-	if ! cfg_parser "$cqfdrc_dir$cqfdrc"; then
-		die "$cqfdrc_dir$cqfdrc: Invalid ini-file!"
+	if ! cfg_parser "$cqfdrc"; then
+		die ".cqfdrc: Invalid ini-file!"
 	fi
 
 	# generate dynamically the list of flavors based on the names of shell
@@ -548,7 +548,7 @@ load_config() {
 
 	# load the [project] section
 	if ! cfg_section_project 2>/dev/null; then
-		die "$cqfdrc: Missing project section!"
+		die ".cqfdrc: Missing project section!"
 	fi
 
 	# shellcheck disable=SC2154
@@ -562,12 +562,12 @@ load_config() {
 
 	# check for [project] org and name properties are set and are not empty
 	if [ -z "$project_org" ] || [ -z "$project_name" ]; then
-		die "$cqfdrc: Missing project.org or project.name properties"
+		die ".cqfdrc: Missing project.org or project.name properties"
 	fi
 
 	# load the [build] section
 	if ! cfg_section_build 2>/dev/null; then
-		die "$cqfdrc: Missing build section!"
+		die ".cqfdrc: Missing build section!"
 	fi
 
 	build_flavors="${flavors[*]}"
@@ -579,7 +579,7 @@ load_config() {
 		if grep -qw "$flavor" <<< "${flavors[*]}"; then
 			# load the [$flavor] section
 			if ! cfg_section_"$flavor" 2>/dev/null; then
-				die "$cqfdrc: Missing $flavor section!"
+				die ".cqfdrc: Missing $flavor section!"
 			fi
 		else
 			die "flavor \"$flavor\" not found in flavors list"
@@ -733,7 +733,7 @@ done
 load_config "$flavor"
 
 if ! $has_alternate_command && [ -n "$*" ] && [ -z "$build_command" ]; then
-	warn "$cqfdrc: Missing or empty build.command property"
+	warn ".cqfdrc: Missing or empty build.command property"
 fi
 
 if $has_alternate_command; then
@@ -743,7 +743,7 @@ elif [ -n "$*" ]; then
 fi
 
 if [ -z "$build_command" ]; then
-	die "$cqfdrc: Missing or empty build.command property"
+	die ".cqfdrc: Missing or empty build.command property"
 fi
 
 docker_run "$build_command"

--- a/cqfd
+++ b/cqfd
@@ -501,8 +501,14 @@ EOF
 ## locate_project_dir() - locate directory with .cqfd upwards
 # stdout: the path to the .cqfd parent directory
 locate_project_dir() {
-	local search_dir="$PWD"
+	local search_dir
 
+	if $has_custom_cqfddir; then
+		realpath "$cqfddir/.."
+		return
+	fi
+
+	search_dir="$PWD"
 	while [ "$search_dir" != "/" ]; do
 		if [ -d "$search_dir"/"$cqfddir" ]; then
 			realpath "$search_dir"
@@ -517,8 +523,14 @@ locate_project_dir() {
 ## load_config() - load build settings from cqfdrc
 # $1: optional "flavor" of the build, is a suffix of command
 load_config() {
+	# get the project directory
 	if ! cqfd_project_dir=$(locate_project_dir); then
 		die ".cqfd directory not found in directory tree"
+	fi
+
+	# unless using '-d other_cqfddir', use base directory located above
+	if ! $has_custom_cqfddir; then
+		cqfddir="$cqfd_project_dir/$cqfddir"
 	fi
 
 	# unless using '-f other_cqfdrc', use base directory located above
@@ -605,7 +617,7 @@ load_config() {
 	# shellcheck disable=SC2154
 	release_tar_opts="$tar_options"
 
-	dockerfile="$cqfd_project_dir/$cqfddir/${build_distro:-docker}/Dockerfile"
+	dockerfile="$cqfddir/${build_distro:-docker}/Dockerfile"
 	if [ ! -f "$dockerfile" ]; then
 		die "$dockerfile not found"
 	fi
@@ -624,6 +636,7 @@ load_config() {
 	fi
 }
 
+has_custom_cqfddir=false
 has_custom_cqfdrc=false
 has_to_release=false
 has_alternate_command=false
@@ -656,6 +669,7 @@ while [ $# -gt 0 ]; do
 		;;
 	-d)
 		shift
+		has_custom_cqfddir=true
 		cqfddir="$1"
 		;;
 	-f)

--- a/tests/05-cqfd_init_alt_ext
+++ b/tests/05-cqfd_init_alt_ext
@@ -27,10 +27,33 @@ else
 fi
 
 ################################################################################
-# 'cqfd init' using alternate filenames in an external directory should work
+# 'cqfd init' using alternate filenames in an external directory using filenames
+# should work
 ################################################################################
-jtest_prepare "cqfd init using alternate filenames in an external directory should work"
+jtest_prepare "cqfd init using alternate filenames in an external directory using filenames should work"
 if "$cqfd" -C "$extdir" -d cqfd -f cqfdrc init; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
+################################################################################
+# 'cqfd init' using alternate filenames in an external directory using absolute
+# filenames should work
+################################################################################
+jtest_prepare "cqfd init using alternate filenames in an external directory using relative filenames should work"
+if "$cqfd" -d "$extdir/cqfd" -f "$extdir/cqfdrc" init; then
+	jtest_result pass
+else
+	jtest_result fail
+fi
+
+################################################################################
+# 'cqfd init' using alternate filenames in an external directory using absolute
+# filenames should work
+################################################################################
+jtest_prepare "cqfd init using alternate filenames in an external directory using absolute filenames should work"
+if "$cqfd" -d "$PWD/$extdir/cqfd" -f "$PWD/$extdir/cqfdrc" init; then
 	jtest_result pass
 else
 	jtest_result fail


### PR DESCRIPTION
The option -f allows absolute .cqfdrc while the option -d allows
directory name "only".

The directory name given to the option -d is used by the function
locate_project_dir() to locate the project directory (i.e. the .cqfd
parent directory). The project directory searches for the directory name
backward starting by the current working directory up to root.

Important: At that point, relative directory works, but it is not
suitable to use more path components than a (single) filename. Using
cqfd -d subdir/to/dot-cqfd works file but the function searches for the
directory "subdir/to/dot-cqfd" and this is not suitable is using option
-C to change directory; cqfd -C subdir/to -d dot-cqfd is preferable.

This allows giving relative and absolute path to option -d to specify
the path to the .cqfd directory to use, by hacking the function
locate_project_dir() to return the parent directory of the .cqfd set by
the option -d, and by prepending the working directory to the cqfddir
variable if the option -d is unset.

Fixes: #173