### PR TITLE
Add a posibility for taking a snapshot of a container

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -42,6 +42,8 @@ Options:
     -d <directory>       Use directory as cqfd directory (default .cqfd).
     -C <directory>       Use the specified working directory.
     -b <flavor_name>     Target a specific build flavor.
+    -s <image_name> <cmdstring>
+                         Run the image with commands.
     -q                   Turn on quiet mode.
     -v or --version      Show version.
     --verbose            Increase the script's verbosity.
@@ -670,6 +672,13 @@ while [ $# -gt 0 ]; do
 	-C)
 		shift
 		cd "$1"
+		;;
+	-s)
+		shift
+		docker_img_name="$1"
+		command_string="$2"
+		docker_run "$command_string"
+		exit
 		;;
 	-q)
 		quiet=true


### PR DESCRIPTION
This adds a `store` command and a `s` option. The command stores the container at a given state and the option can be used to run the stored image.

Ideally, it also needs a cqfd delete for clean up as it creates new images (see https://github.com/savoirfairelinux/cqfd/issues/233).