### PR TITLE
tests: 10-cqfd_doutofd: drop unnecessary option -i

### DIFF
--- a/tests/10-cqfd_doutofd
+++ b/tests/10-cqfd_doutofd
@@ -20,7 +20,7 @@ if [ "$cqfd_docker" != "docker" ] || ! getent group docker | grep -q "$USER"; th
 	jtest_result skip
 else
 	cp -f .cqfd/docker/Dockerfile.doutofd .cqfd/docker/Dockerfile
-	sed -i -e "/\[build\]/,/^$/s,^command=.*$,command='docker run --rm -ti ubuntu:24.04 cat /etc/os-release'," .cqfdrc
+	sed -i -e "/\[build\]/,/^$/s,^command=.*$,command='docker run --rm -t ubuntu:24.04 cat /etc/os-release'," .cqfdrc
 
 	if "$cqfd" init && CQFD_BIND_DOCKER_SOCK=true "$cqfd" | grep -qE 'PRETTY_NAME="Ubuntu 24.04(.[[:digit:]]+)? LTS"'; then
 		jtest_result pass


### PR DESCRIPTION
The -i (interactive) flag was previously added to docker run, but it is not needed when the command only outputs a file to stdout.

In GitHub Actions, workflows are executed with pipes connected to stdin, stdout, and stderr. Because stdin is a pipe, running docker run -ti fails.

This change removes the unnecessary -i option, ensuring the test "cqfd run docker using host docker daemon" works correctly in CI environments.

Fixes:

	[18:30:29|notice] preparing: "cqfd run docker using host docker daemon"
	#0 building with "default" instance using docker driver
	(...)
	(+ docker run --privileged --rm --log-driver=none --env HOME=/home/runner --volume /home/runner/.ssh:/home/runner/.ssh --volume /etc/ssh:/etc/ssh --volume /var/run/docker.sock:/var/run/docker.sock --volume /tmp/cqfd-test.CitHWV:/tmp/cqfd-test.CitHWV --workdir /tmp/cqfd-test.CitHWV --volume /tmp/cqfd-entrypoint.ew1pk5:/bin/cqfd-entrypoint --entrypoint /bin/cqfd-entrypoint cqfd-runner-cqfd-test-linux_amd64-docker:b760571 'docker run --rm -ti ubuntu:24.04 cat /etc/os-release')
	(+ rm -f /tmp/cqfd-entrypoint.ew1pk5)
	the input device is not a TTY
	[18:30:54|info] result: "cqfd run docker using host docker daemon": FAIL
	(...)
	**|FAIL|cqfd run docker using host docker daemon