### PR TITLE
cqfd: use CQFD_HISTFILE

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,9 @@ the cqfd group in the container.
 
 `CQFD_SHELL`: The shell to be launched, by default `/bin/sh`.
 
+`CQFD_HISTFILE`: This file will be used as the shell history file for all the
+shells supported in the [shell history](#shell-history) section.
+
 `CQFD_DISABLE_SHELL_HISTORY`: Set to `true` to disable bind mounting the shell
 history file in the container and setting the HISTFILE variable
 

--- a/cqfd
+++ b/cqfd
@@ -882,6 +882,7 @@ while [ $# -gt 0 ]; do
 			break
 		fi
 
+		# set HISTFILE if using `cqfd run bash`
 		set_shell_histfile "$1"
 		# Run alternate command
 		has_alternate_command=true

--- a/cqfd
+++ b/cqfd
@@ -754,14 +754,14 @@ set_shell_histfile() {
 
 	case "$program_basename" in
 	bash|zsh)
-		shell_histfile="${HISTFILE:-$HOME/.${program_basename}_history}"
+		shell_histfile="${CQFD_HISTFILE:-$HOME/.${program_basename}_history}"
 		;;
 	ksh)
-		shell_histfile="${HISTFILE:-$HOME/.sh_history}"
+		shell_histfile="${CQFD_HISTFILE:-$HOME/.sh_history}"
 		;;
 	tcsh)
 		# Note: tcsh history does not persist without doing `history -S` on exit
-		shell_histfile="${HISTFILE:-$HOME/.history}"
+		shell_histfile="${CQFD_HISTFILE:-$HOME/.history}"
 		;;
 	*)
 		shell_histfile=""

--- a/tests/11-shell_history.bats
+++ b/tests/11-shell_history.bats
@@ -3,9 +3,8 @@
 setup() {
     load 'test_helper/common-setup'
     _common_setup
-    HISTFILE=$(mktemp "/tmp/tmp.bats-cqfd-XXXXX")
-    export HISTFILE
-    shell_histfile=${HISTFILE}
+    CQFD_HISTFILE=$(mktemp "/tmp/tmp.bats-cqfd-XXXXX")
+    export CQFD_HISTFILE
     commands_file="$BATS_TEST_TMPDIR/commands.txt"
 }
 
@@ -17,8 +16,8 @@ run_shell_commands() {
     string_to_check="hello from the other side $shell_name"
     echo "echo $string_to_check" > "$commands_file"
 
-    if [ "$rm_histfile" = "true" ] && [ -f "$shell_histfile" ]; then
-        rm -f "$shell_histfile"
+    if [ "$rm_histfile" = "true" ] && [ -f "$CQFD_HISTFILE" ]; then
+        rm -f "$CQFD_HISTFILE"
     fi
 
     if [ -n "$exec_or_run" ]; then
@@ -35,8 +34,8 @@ run_shell_commands() {
     assert_success
     assert_line --partial "$string_to_check"
 
-    # test that the commands run are now in the $shell_histfile
-    run tail "$shell_histfile"
+    # test that the commands run are now in the $CQFD_HISTFILE
+    run tail "$CQFD_HISTFILE"
     if [ "$history_not_saved" = "true" ]; then
         assert_failure
     else


### PR DESCRIPTION
The variable HISTFILE is not exported in most shells so cqfd cannot read it. And if we don’t use the same shell on the host and in cqfd then we don’t want to share the histfile. So it is more convenient to use CQFD_HISTFILE to set the HISTFILE in cqfd