### PR TITLE
Add warning run multiple arguments

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -866,6 +866,7 @@ while [ $# -gt 0 ]; do
 			has_to_release=true
 		fi
 
+		cqfd_command="$1"
 		shift
 
 		# No more args? run default command
@@ -877,7 +878,7 @@ while [ $# -gt 0 ]; do
 
 			if [ "$#" -lt 1 ]; then
 				usage
-				die "run -c: Missing arguments!"
+				die "$cqfd_command -c: Missing arguments!"
 			fi
 			break
 		fi
@@ -886,6 +887,28 @@ while [ $# -gt 0 ]; do
 		set_shell_histfile "$1"
 		# Run alternate command
 		has_alternate_command=true
+
+		# Display a warning message if using run with at least one quoted argument
+		show_error_message=false
+		if [ "$#" -gt 1 ]; then
+			# Rebuild the initial command with quotes only for arguments containing spaces
+			initial_command=""
+			for arg in "$@"; do
+				if [[ $arg = *" "* ]]; then
+					initial_command+="'$arg' "
+					show_error_message=true
+				else
+					initial_command+="$arg "
+				fi
+			done
+			initial_command=${initial_command%?}
+			if "$show_error_message"; then
+				warn "command '$cqfd_command' with multiple arguments is ambiguous," \
+					"please consider the commands 'exec' or 'shell' instead:"
+				echo "               cqfd exec $initial_command" >&2
+				echo "               cqfd shell -c \"$initial_command\"" >&2
+			fi
+		fi
 		break
 		;;
 	sh|ash|dash|bash|ksh|zsh|csh|tcsh|fish|shell)

--- a/tests/05-cqfd_run_command.bats
+++ b/tests/05-cqfd_run_command.bats
@@ -32,3 +32,14 @@ teardown() {
     run cqfd run /bin/sh -c 'printf "0=$0,*=$*,#=$#"' zero one two three
     assert_line --regexp "0=(\/bin\/)?sh,\*=,#=0"
 }
+
+@test "cqfd run with a quoted argument triggers a warning message" {
+    run cqfd run touch "this is a filename"
+    assert_line --partial "cqfd exec touch 'this is a filename'"
+    assert_line --partial "cqfd shell -c \"touch 'this is a filename'\""
+}
+
+@test "cqfd run without a quoted argument DOES NOT trigger a warning message" {
+    run cqfd run touch these are multiple filenames
+    refute_output
+}


### PR DESCRIPTION
The command 'run' is ambiguous.

This adds a warning if the command is run with multiple arguments telling to use either 'exec' or 'shell', depending if the arguments is simple command or a list of commands.

See 344969c0de765faba5a22c8cb470e4efe63b2047.