### PR TITLE
cqfd: allow to use a symlinked Dockerfile

### DIFF
--- a/cqfd
+++ b/cqfd
@@ -188,7 +188,7 @@ docker_build() {
 
 	# Set the context
 	if [ -z "$project_build_context" ]; then
-		args+=("$(dirname "$dockerfile")")
+		args+=("$(dirname "$dockerfile")" --file "$dockerfile")
 	else
 		args+=("$project_build_context" --file "$dockerfile")
 	fi
@@ -728,7 +728,7 @@ load_config() {
 	# shellcheck disable=SC2154
 	release_tar_options="$tar_options"
 
-	dockerfile="$cqfddir/${build_distro:-docker}/Dockerfile"
+	dockerfile=$(realpath "$cqfddir/${build_distro:-docker}/Dockerfile")
 	if [ ! -f "$dockerfile" ]; then
 		die "$dockerfile not found"
 	fi

--- a/tests/05-cqfd_run_dockerfile_symlink.bats
+++ b/tests/05-cqfd_run_dockerfile_symlink.bats
@@ -1,0 +1,25 @@
+#!/usr/bin/env bats
+
+setup_file() {
+    mkdir -p .cqfd-symlink/docker
+}
+
+setup() {
+    load 'test_helper/common-setup'
+    _common_setup
+}
+
+teardown_file() {
+    rm -r .cqfd-symlink
+}
+
+@test "cqfd init fails without a Dockerfile" {
+    run cqfd -d .cqfd-symlink init
+    assert_failure
+}
+
+@test "cqfd init succeeds with symlinked Dockerfile" {
+    ln -s ../../.cqfd/docker/Dockerfile .cqfd-symlink/docker/Dockerfile
+    run cqfd -d .cqfd-symlink init
+    assert_success
+}

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,6 +1,7 @@
 .PHONY: tests check
 
 tests: CQFD_DOCKER =
+tests: CQFD_DEBUG =
 tests: CQFD_EXTRA_RUN_ARGS =
 tests: CQFD_EXTRA_BUILD_ARGS =
 tests: CQFD_EXTRA_RMI_ARGS =


### PR DESCRIPTION
This commit makes it possible for `.cqfd/docker/Dockerfile` to be a symlink. This allows projects which already have a Dockerfile stored somewhere to make a symlink to it for cqfd.