### PR TITLE
Internal variable names consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,11 +304,11 @@ supported.
 
 For tar archives:
 
-* Setting `tar_transform=yes` (optional) will cause all files specified for
-  the archive to be stored at the root of the archive, which is desired in some
-  scenarios.
+* (Optional) Setting `tar_transform=yes` or `tar_transform=true` will cause all
+  files specified for the archive to be stored at the root of the archive, which
+  is desired in some scenarios.
 
-* Setting `tar_options` (optional) will pass extra options to the tar
+* (Optional) Setting `tar_options` will pass extra options to the tar
   command. For example, setting `tar_options=-h` will copy all symlink files
   as hardlinks, which is desired in some scenarios.
 

--- a/cqfd
+++ b/cqfd
@@ -470,8 +470,9 @@ make_archive() {
 	# also replace variable names - beware with eval
 	eval "release_archive=$release_archive"
 
-	# setting tar_transform=yes will move files to the root of a tar archive
-	if [ "$release_tar_transform" = "yes" ]; then
+	# setting tar_transform=yes or tar_transform=true will move files to the
+	# root of a tar archive
+	if [ "$release_tar_transform" = "yes" ] || [ "$release_tar_transform" = "true" ]; then
 		tar_opts+=('--transform' 's/.*\///g')
 	fi
 

--- a/cqfd
+++ b/cqfd
@@ -471,15 +471,15 @@ make_archive() {
 	eval "release_archive=$release_archive"
 
 	# setting tar_transform=yes will move files to the root of a tar archive
-	if [ "$release_transform" = "yes" ]; then
+	if [ "$release_tar_transform" = "yes" ]; then
 		tar_opts+=('--transform' 's/.*\///g')
 	fi
 
 	# setting tar_options=x will pass the options to tar
-	if [ "$release_tar_opts" ]; then
+	if [ "$release_tar_options" ]; then
 		local array
 		# shellcheck disable=SC2162
-		read -a array <<<"$release_tar_opts"
+		read -a array <<<"$release_tar_options"
 		tar_opts+=("${array[@]}")
 	fi
 
@@ -723,9 +723,9 @@ load_config() {
 	# shellcheck disable=SC2154
 	release_archive="$archive"
 	# shellcheck disable=SC2154
-	release_transform="$tar_transform"
+	release_tar_transform="$tar_transform"
 	# shellcheck disable=SC2154
-	release_tar_opts="$tar_options"
+	release_tar_options="$tar_options"
 
 	dockerfile="$cqfddir/${build_distro:-docker}/Dockerfile"
 	if [ ! -f "$dockerfile" ]; then

--- a/tests/06-cqfd_release.bats
+++ b/tests/06-cqfd_release.bats
@@ -73,6 +73,21 @@ teardown_file() {
     rm -f cqfd-test.tar.xz
 }
 
+@test "archived files at root of tar archive if tar_transform=true" {
+    echo "tar_transform=true" >>.cqfdrc
+    cqfd release
+    result="pass"
+    for f in $rel_files; do
+        if ! tar tf cqfd-test.tar.xz | grep -q "^$(basename "$f")$"; then
+            result="fail"
+        fi
+    done
+    run [ "$result" = "pass" ]
+    assert_success
+    sed -i -e '$ s!^tar_transform=.*$!!' .cqfdrc
+    rm -f cqfd-test.tar.xz
+}
+
 @test "symlink files are copied in the tar archive" {
     cqfd run ln -s a/cqfd_a.txt link.txt
     rel_files_link="a/cqfd_a.txt link.txt"


### PR DESCRIPTION
In this PR the name of internal variables is changed to be more consistent with the name of the options in the configuration file.

We also accept `true` for `tar_transform` as this is the only option expecting `yes` while all other options in cqfd expect to be set to `true`