### PR TITLE
tests: replace centos by fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,9 +323,9 @@ In the `.cqfdrc` file, one or more flavors may be listed in the
 flavor's name.
 
 ```ini
-[centos7]
-command='make CENTOS=1'
-distro='centos7'
+[fedora]
+command='make FEDORA=1'
+distro='fedora'
 
 [debug]
 command='make DEBUG=1'
@@ -404,8 +404,8 @@ The `-c` option set immediately after the command run allows appending the
 command of a cqfd run for temporary developments:
 
 ```sh
-cqfd -b centos7 run -c "clean"
-cqfd -b centos7 run -c "TRACING=1"
+cqfd -b fedora run -c "clean"
+cqfd -b fedora run -c "TRACING=1"
 ```
 
 ### Running a shell in the container
@@ -547,7 +547,7 @@ cqfd deinit
 If a flavor redefines the distro key of the build section, use:
 
 ```sh
-cqfd -b centos7 deinit
+cqfd -b fedora deinit
 ```
 
 To list all cqfd images across all user projects on the system, use:

--- a/cqfd.1.adoc
+++ b/cqfd.1.adoc
@@ -196,8 +196,8 @@ another container or another build command.
 The _-c_ option set immediately after the command run allows appending the
 command of a cqfd run for temporary developments.
 
-	$ cqfd -b centos7 run -c "clean"
-	$ cqfd -b centos7 run -c "TRACING=1"
+	$ cqfd -b fedora run -c "clean"
+	$ cqfd -b fedora run -c "TRACING=1"
 
 === RUNNING A SHELL IN THE CONTAINER
 

--- a/cqfdrc.5.adoc
+++ b/cqfdrc.5.adoc
@@ -151,9 +151,9 @@ build and release methods (for example a debug build). This is made possible in
 In the _.cqfdrc_ file, one or more flavors may be listed in the _[build]_
 section, referencing other sections named following flavor's name.
 
-	[centos7]
-	command='make CENTOS=1'
-	distro='centos7'
+	[fedora]
+	command='make FEDORA=1'
+	distro='fedora'
 
 	[debug]
 	command='make DEBUG=1'

--- a/tests/01-cqfd_init.bats
+++ b/tests/01-cqfd_init.bats
@@ -26,7 +26,7 @@ teardown() {
 }
 
 @test "'cqfd init' with a proper Dockerfile should pass" {
-    sed -i -e "s/\[build\]/[build]\ndistro='centos'/" .cqfdrc
+    sed -i -e "s/\[build\]/[build]\ndistro='fedora'/" .cqfdrc
     run cqfd init
     assert_success
 }

--- a/tests/05-cqfd_init_flavor.bats
+++ b/tests/05-cqfd_init_flavor.bats
@@ -8,11 +8,11 @@ setup() {
 
 @test "'cqfd init' with different flavor makes a different container" {
     cp -f .cqfdrc .cqfdrc.old
-    sed -i -e "s/\[foo\]/[foo]\ndistro='centos'/" .cqfdrc
+    sed -i -e "s/\[foo\]/[foo]\ndistro='fedora'/" .cqfdrc
     run cqfd -b "$flavor" init
     assert_success
     run cqfd -b "$flavor" run "grep '^NAME=' /etc/*release"
-    assert_line --partial "NAME=\"CentOS Linux\""
+    assert_line --partial "NAME=\"Fedora Linux\""
 }
 
 @test "'cqfd init' with invalid flavor should fail" {

--- a/tests/90-cqfd_deinit.bats
+++ b/tests/90-cqfd_deinit.bats
@@ -18,7 +18,7 @@ setup() {
 }
 
 @test "'cqfd deinit' with a proper Dockerfile should fail" {
-    sed -i -e "s/thisshouldfail/centos/" .cqfdrc
+    sed -i -e "s/thisshouldfail/fedora/" .cqfdrc
     run cqfd init
     assert_success
     run cqfd deinit

--- a/tests/test_data/.cqfd/centos/Dockerfile
+++ b/tests/test_data/.cqfd/centos/Dockerfile
@@ -1,2 +1,0 @@
-FROM centos:centos7
-LABEL org.opencontainers.image.authors="cloud-ops@centos.org"

--- a/tests/test_data/.cqfd/fedora/Dockerfile
+++ b/tests/test_data/.cqfd/fedora/Dockerfile
@@ -1,0 +1,1 @@
+FROM fedora:43


### PR DESCRIPTION
Since CentOS is not maintained anymore, we use fedora as an alternative docker image so the tests can continue to be updated

The CentOS was causing an error locally when running the tests. Changing to a modern version of Fedora fixes the error