### PR TITLE
Forward system gitconfig to container

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,9 @@ the user's `~/.ssh` configuration to the container.
 `CQFD_NO_USER_GIT_CONFIG`: Set to `true` to disable forwarding
 the user's `~/.gitconfig` configuration to the container.
 
+`CQFD_NO_SYSTEM_GIT_CONFIG`: Set to `true` to disable forwarding
+the system's `/etc/gitconfig` configuration to the container.
+
 `CQFD_NO_SSH_AUTH_SOCK`: Set to `true` to disable forwarding the
 SSH authentication socket to the container.
 

--- a/README.md
+++ b/README.md
@@ -429,14 +429,14 @@ defined container.
 Example:
 
 ```sh
-fred@host:~/project$ cat get-container-pretty-name.sh 
+fred@host:~/project$ cat get-container-pretty-name.sh
 #!/usr/bin/env -S cqfd shell
 if ! test -e /.dockerenv; then
     exit 1
 fi
 source /etc/os-release
 echo "$PRETTY_NAME"
-fred@host:~/project$ ./get-container-pretty-name.sh 
+fred@host:~/project$ ./get-container-pretty-name.sh
 Debian GNU/Linux 12 (bookworm)
 ```
 

--- a/cqfd
+++ b/cqfd
@@ -374,6 +374,10 @@ docker_run() {
 		args+=(--mount "type=bind,src=$HOME/.gitconfig,dst=$cqfd_user_home/.gitconfig")
 	fi
 
+	if [ "$CQFD_NO_SYSTEM_GIT_CONFIG" != true ] && [ -f "/etc/gitconfig" ]; then
+		args+=(--mount "type=bind,src=/etc/gitconfig,dst=/etc/gitconfig")
+	fi
+
 	if [ "$CQFD_BIND_DOCKER_SOCK" = true ] || [ "$build_bind_docker_sock" = true ]; then
 		args+=(--volume /var/run/docker.sock:/var/run/docker.sock)
 	fi

--- a/cqfd.1.adoc
+++ b/cqfd.1.adoc
@@ -164,6 +164,10 @@ another container or another build command.
 	Set to _true_ to disable forwarding the user's _~/.gitconfig_
 	configuration to the container.
 
+*CQFD_NO_SYSTEM_GIT_CONFIG*::
+	Set to _true_ to disable forwarding the system's _/etc/gitconfig_
+	configuration to the container.
+
 *CQFD_NO_SSH_AUTH_SOCK*::
 	Set to _true_ to disable forwarding the SSH authentication socket to
 	the container.

--- a/tests/05-cqfd_run_system_git_config.bats
+++ b/tests/05-cqfd_run_system_git_config.bats
@@ -1,0 +1,29 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common-setup'
+    _common_setup
+}
+
+@test "'cqfd run' forwards system git config to container when /etc/gitconfig exists" {
+    # Skip this test if /etc/gitconfig doesn't exist on the system
+    if [ ! -f "/etc/gitconfig" ]; then
+        skip "/etc/gitconfig does not exist on this system"
+    fi
+
+    # Verify that the system git config is accessible inside the container
+    run cqfd run 'test -f /etc/gitconfig'
+    assert_success
+}
+
+@test "'cqfd run' disables system git config forwarding with CQFD_NO_SYSTEM_GIT_CONFIG=true" {
+    # Skip this test if /etc/gitconfig doesn't exist on the system
+    if [ ! -f "/etc/gitconfig" ]; then
+        skip "/etc/gitconfig does not exist on this system"
+    fi
+
+    # Verify that the system git config is not accessible when disabled
+    CQFD_NO_SYSTEM_GIT_CONFIG=true \
+        run cqfd run 'test ! -f /etc/gitconfig'
+    assert_success
+}

--- a/tests/05-cqfd_run_system_ssh_config.bats
+++ b/tests/05-cqfd_run_system_ssh_config.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common-setup'
+    _common_setup
+}
+
+@test "'cqfd run' forwards system SSH config to container when /etc/ssh exists" {
+    if [ ! -d "/etc/ssh" ]; then
+        skip "/etc/ssh does not exist on this system"
+    fi
+
+    host_stat=$(stat -c '%d:%i' /etc/ssh)
+
+    run cqfd run "stat -c '%d:%i' /etc/ssh"
+    assert_success
+    assert_line "$host_stat"
+}
+
+@test "'cqfd run' disables system SSH config forwarding with CQFD_NO_SSH_CONFIG=true" {
+    if [ ! -d "/etc/ssh" ]; then
+        skip "/etc/ssh does not exist on this system"
+    fi
+
+    host_stat=$(stat -c '%d:%i' /etc/ssh)
+
+    CQFD_NO_SSH_CONFIG=true \
+        run cqfd run "if [ -e /etc/ssh ]; then test \"\$(stat -c '%d:%i' /etc/ssh)\" != '$host_stat'; fi"
+    assert_success
+}

--- a/tests/05-cqfd_run_user_git_config.bats
+++ b/tests/05-cqfd_run_user_git_config.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common-setup'
+    _common_setup
+}
+
+@test "'cqfd run' forwards user git config to container when ~/.gitconfig exists" {
+    if [ ! -f "$HOME/.gitconfig" ]; then
+        skip "$HOME/.gitconfig does not exist on this system"
+    fi
+
+    host_stat=$(stat -c '%d:%i' "$HOME/.gitconfig")
+
+    run cqfd run "stat -c '%d:%i' \$HOME/.gitconfig"
+    assert_success
+    assert_line "$host_stat"
+}
+
+@test "'cqfd run' disables user git config forwarding with CQFD_NO_USER_GIT_CONFIG=true" {
+    if [ ! -f "$HOME/.gitconfig" ]; then
+        skip "$HOME/.gitconfig does not exist on this system"
+    fi
+
+    host_stat=$(stat -c '%d:%i' "$HOME/.gitconfig")
+
+    CQFD_NO_USER_GIT_CONFIG=true \
+        run cqfd run "if [ -e \$HOME/.gitconfig ]; then test \"\$(stat -c '%d:%i' \$HOME/.gitconfig)\" != '$host_stat'; fi"
+    assert_success
+}

--- a/tests/05-cqfd_run_user_ssh_config.bats
+++ b/tests/05-cqfd_run_user_ssh_config.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+
+setup() {
+    load 'test_helper/common-setup'
+    _common_setup
+}
+
+@test "'cqfd run' forwards user SSH config to container when ~/.ssh exists" {
+    if [ ! -d "$HOME/.ssh" ]; then
+        skip "$HOME/.ssh does not exist on this system"
+    fi
+
+    host_stat=$(stat -c '%d:%i' "$HOME/.ssh")
+
+    run cqfd run "stat -c '%d:%i' \$HOME/.ssh"
+    assert_success
+    assert_line "$host_stat"
+}
+
+@test "'cqfd run' disables user SSH config forwarding with CQFD_NO_USER_SSH_CONFIG=true" {
+    if [ ! -d "$HOME/.ssh" ]; then
+        skip "$HOME/.ssh does not exist on this system"
+    fi
+
+    host_stat=$(stat -c '%d:%i' "$HOME/.ssh")
+
+    CQFD_NO_USER_SSH_CONFIG=true \
+        run cqfd run "if [ -e \$HOME/.ssh ]; then test \"\$(stat -c '%d:%i' \$HOME/.ssh)\" != '$host_stat'; fi"
+    assert_success
+}


### PR DESCRIPTION
Some sysadmins pass some global proxy configuration in the system gitconfig, and it can be useful to forward it to the container as well. This commits adds a feature to pass it by default, like the user gitconfig, and a new environment variable `CQFD_NO_SYSTEM_GIT_CONFIG` to disable it if needed. This follows the same approach as the user gitconfig or ssh forwarding.