### PR TITLE
prepare for v5.10.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog for cqfd
 
-## Version 5.10.0 (2026-04-23)
+## Version 5.10.1 (2026-04-24)
 
 * Better handling of user deletion if conflicting in container. This affects
   mostly Ubuntu 24.04 containers

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Jérôme Oufella <jerome.oufella@savoirfairelinux.com>
 
 pkgname=cqfd
-pkgver=5.10.0
+pkgver=5.10.1
 pkgrel=1
 pkgdesc='Wrap commands in controlled Docker containers using docker.'
 arch=(any)

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ build environment for your project.
 First download the package, then install it with the package manager:
 
 ```sh
-curl -LO https://github.com/savoirfairelinux/cqfd/releases/download/v5.10.0/cqfd_5.10.0_all.deb
-sudo apt install ./cqfd_5.10.0_all.deb
+curl -LO https://github.com/savoirfairelinux/cqfd/releases/download/v5.10.1/cqfd_5.10.1_all.deb
+sudo apt install ./cqfd_5.10.1_all.deb
 ```
 
 _Note_: Uninstall it using the package manager:
@@ -52,8 +52,8 @@ sudo apt remove cqfd
 First download the package, then install it with the package manager:
 
 ```sh
-curl -LO https://github.com/savoirfairelinux/cqfd/releases/download/v5.10.0/cqfd-5.10.0-1.noarch.rpm
-sudo dnf install ./cqfd-5.10.0-1.noarch.rpm
+curl -LO https://github.com/savoirfairelinux/cqfd/releases/download/v5.10.1/cqfd-5.10.1-1.noarch.rpm
+sudo dnf install ./cqfd-5.10.1-1.noarch.rpm
 ```
 
 _Note_: Uninstall it using the package manager:
@@ -67,8 +67,8 @@ sudo dnf remove cqfd
 First download the package, then install it with the package manager:
 
 ```sh
-curl -LO https://github.com/savoirfairelinux/cqfd/releases/download/v5.10.0/cqfd-5.10.0-1-any.pkg.tar.zst
-sudo pacman -U ./cqfd-5.10.0-1-any.pkg.tar.zst
+curl -LO https://github.com/savoirfairelinux/cqfd/releases/download/v5.10.1/cqfd-5.10.1-1-any.pkg.tar.zst
+sudo pacman -U ./cqfd-5.10.1-1-any.pkg.tar.zst
 ```
 
 _Note_: Uninstall it using the package manager:
@@ -94,7 +94,7 @@ and its resources:
 ```sh
 git clone --recurse-submodules https://github.com/savoirfairelinux/cqfd.git
 cd cqfd
-git checkout v5.10.0
+git checkout v5.10.1
 sudo make install
 ```
 

--- a/cqfd
+++ b/cqfd
@@ -21,7 +21,7 @@ set -e
 set -o pipefail
 
 PROGNAME=$(basename "$0")
-VERSION=5.10.0
+VERSION=5.10.1
 cqfddir=".cqfd"
 cqfdrc=".cqfdrc"
 cqfd_user="${USER:-'builder'}"

--- a/cqfd.1.adoc
+++ b/cqfd.1.adoc
@@ -4,7 +4,7 @@
 :email: jerome.oufella@savoirfairelinux.com
 :lang: en
 :man manual: C.Q.F.D. Manual
-:man source: C.Q.F.D. Project 5.10.0
+:man source: C.Q.F.D. Project 5.10.1
 
 == NAME
 

--- a/cqfd.spec
+++ b/cqfd.spec
@@ -1,5 +1,5 @@
 Name:           cqfd
-Version:        5.10.0
+Version:        5.10.1
 Release:        1
 Summary:        Wrap commands in controlled Docker containers using docker
 
@@ -52,7 +52,7 @@ make check
 
 %changelog
 
-* Thu Apr 23 2026 Florent Allard <florent.allard@savoirfairelinux.com> - 5.10.0-1
+* Thu Apr 24 2026 Florent Allard <florent.allard@savoirfairelinux.com> - 5.10.1-1
 - Better handling of user deletion if conflicting in container. This affects
   mostly Ubuntu 24.04 containers
 - Allow to use a symlinked Dockerfile in .cqfd

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-cqfd (5.10.0) stable; urgency=low
+cqfd (5.10.1) stable; urgency=low
 
   * Better handling of user deletion if conflicting in container. This affects
     mostly Ubuntu 24.04 containers
@@ -8,7 +8,7 @@ cqfd (5.10.0) stable; urgency=low
   * Allow to set the HISTFILE to bind in `cqfd` using `CQFD_HISTFILE`
   * Allow to forward system gitconfig to container
 
- -- Florent Allard <florent.allard@savoirfairelinux.com>  Thu, 23 Apr 2026 20:00:00 +0200
+ -- Florent Allard <florent.allard@savoirfairelinux.com>  Thu, 24 Apr 2026 20:00:00 +0200
 
 cqfd (5.9.0) stable; urgency=low
 


### PR DESCRIPTION
The release failed because Actions were not able to upload artifacts to the releases because of immutable releases.

The procedure to release is:

- Create a new draft release with the new tag like v5.10.1
- Push the tag v5.10.1 to the repo
- Wait for Actions to upload the assets
- Validate the release so it becomes immutable

So we have to increment the tag to have this behavior